### PR TITLE
FIX: author

### DIFF
--- a/backend/apps/community/serializers.py
+++ b/backend/apps/community/serializers.py
@@ -40,6 +40,14 @@ class PostListSerializer(serializers.ModelSerializer):
         if first_image:
             return first_image.file.url
         return None
+    
+    def to_representation(self, instance):
+        data = super().to_representation(instance)
+
+        if instance.is_anonymous:
+            data["author"] = None
+
+        return data
 
 # 게시글 상세 Serializer
 class PostDetailSerializer(serializers.ModelSerializer):
@@ -79,6 +87,14 @@ class PostDetailSerializer(serializers.ModelSerializer):
         if request and request.user.is_authenticated:
             return obj.reactions.filter(user=request.user).exists()
         return False
+    
+    def to_representation(self, instance):
+        data = super().to_representation(instance)
+
+        if instance.is_anonymous:
+            data["author"] = None
+
+        return data
 
 
 class PostCreateSerializer(serializers.ModelSerializer):
@@ -241,5 +257,8 @@ class CommentSerializer(serializers.ModelSerializer):
 
         if instance.is_deleted:
             data["content"] = "삭제된 댓글입니다."
+
+        if instance.post.is_anonymous:
+            data["author"] = None
 
         return data


### PR DESCRIPTION
## 🔗 관련 이슈
- close #8

---

## 📌 작업 유형
- [ ] FE
- [x] BE

---

## ✨ 작업 내용
### BE
- 게시글/댓글 작성자 정보는 닉네임 기준으로 통일
- 익명 게시글의 경우 author 필드를 null로 반환하여 프로필 조회(hover 카드)가 불가능하도록 처리
- 실명 정보는 API 응답에 포함하지 않음
---
