### PR TITLE
FIX: API 경로 동일화 + 경로 에러 수정

### DIFF
--- a/frontend/src/app/(auth)/login/kakao-callback/page.tsx
+++ b/frontend/src/app/(auth)/login/kakao-callback/page.tsx
@@ -4,8 +4,8 @@ import { Suspense } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useEffect, useState } from "react";
 import Logo from "@/shared/components/layout/Logo";
+import{ API_BASE } from "@/shared/api/api";
 
-const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
 
 function KakaoCallbackContent() {
   const router = useRouter();

--- a/frontend/src/app/(auth)/login/page.tsx
+++ b/frontend/src/app/(auth)/login/page.tsx
@@ -4,8 +4,8 @@ import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
 import Logo from "@/shared/components/layout/Logo";
+import{ API_BASE } from "@/shared/api/api";
 
-const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
 const KAKAO_REST_KEY = process.env.NEXT_PUBLIC_KAKAO_REST_API_KEY ?? "";
 
 export default function LoginPage() {

--- a/frontend/src/app/(auth)/onboarding/page.tsx
+++ b/frontend/src/app/(auth)/onboarding/page.tsx
@@ -4,8 +4,7 @@ import { Suspense, useState, useEffect } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import Link from "next/link";
 import Logo from "@/shared/components/layout/Logo";
-
-const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
+import{ API_BASE } from "@/shared/api/api";
 
 type UserType = "student" | "graduate";
 

--- a/frontend/src/app/(main)/profile/edit/page.tsx
+++ b/frontend/src/app/(main)/profile/edit/page.tsx
@@ -3,8 +3,7 @@
  import { Save, X, Upload } from "lucide-react";
  import { useRouter } from "next/navigation";
  import { useEffect, useState } from "react";
-
- const API_BASE = "http://localhost:8000";
+import{ API_BASE } from "@/shared/api/api";
 
  type UserType = "student" | "graduate";
 

--- a/frontend/src/app/(main)/profile/page.tsx
+++ b/frontend/src/app/(main)/profile/page.tsx
@@ -13,8 +13,7 @@
  import Link from "next/link";
  import { useRouter } from "next/navigation";
  import { useEffect, useState } from "react";
-
- const API_BASE = "http://localhost:8000";
+ import{ API_BASE } from "@/shared/api/api";
 
  type UserType = "student" | "graduate";
 

--- a/frontend/src/app/messages/page.tsx
+++ b/frontend/src/app/messages/page.tsx
@@ -57,7 +57,7 @@ function MessagesPageContent(){
   // 대화 목록 조회
   const fetchConversations = async (): Promise<Conversation[]> => {
     try {
-      const res = await api.get("/messages/conversations/");
+      const res = await api.get("messages/conversations/");
       const data = res.data.results || res.data;
 
       const formatted = data.map((c: any) => ({
@@ -84,7 +84,7 @@ function MessagesPageContent(){
   const fetchMessages = async (conversationId: number) => {
     try {
       const res = await api.get(
-        `/messages/conversations/${conversationId}/messages/`
+        `messages/conversations/${conversationId}/messages/`
       );
 
       const formatted = res.data.map((m: any) => ({
@@ -113,7 +113,7 @@ function MessagesPageContent(){
     if (!replyText.trim() || !selectedConversation) return;
 
     try {
-      await api.post("/messages/messages/", {
+      await api.post("messages/messages/", {
         conversation: selectedConversation.id,
         content: replyText,
       });
@@ -138,7 +138,7 @@ function MessagesPageContent(){
   // 새 대화 생성
   const createConversation = async (userId: number) => {
     try {
-      await api.post("/messages/conversations/", {
+      await api.post("messages/conversations/", {
         user_id: userId,
       });
     } catch (err) {
@@ -150,9 +150,9 @@ function MessagesPageContent(){
   const handleContactAdmin = async () => {
     setContactingAdmin(true);
     try {
-      const adminRes = await api.get("/users/admin-info/");
+      const adminRes = await api.get("users/admin-info/");
       const adminId = adminRes.data.id;
-      const convRes = await api.post("/messages/start/", { user_id: adminId });
+      const convRes = await api.post("messages/start/", { user_id: adminId });
       const conv: Conversation = {
         id: convRes.data.id,
         other_user: {
@@ -208,7 +208,7 @@ function MessagesPageContent(){
   }, [targetUserId, conversations]);
 
   useEffect(() => {
-    api.get("/users/me/").then((res) => setIsAdmin(!!res.data?.is_staff)).catch(() => {});
+    api.get("users/me/").then((res) => setIsAdmin(!!res.data?.is_staff)).catch(() => {});
   }, []);
 
   return (

--- a/frontend/src/app/notifications/page.tsx
+++ b/frontend/src/app/notifications/page.tsx
@@ -40,7 +40,7 @@ function NotificationsPageContent() {
 
   const fetchNotifications = async () => {
     try {
-      const res = await api.get("/notifications/");
+      const res = await api.get("notifications/");
       setNotifications(res.data.results);
     } catch (err) {
       console.error("알림 불러오기 실패", err);
@@ -52,7 +52,7 @@ function NotificationsPageContent() {
   const handleClick = async (notification: Notification) => {
     try {
       if (!notification.is_read) {
-        await api.patch(`/notifications/${notification.id}/read/`);
+        await api.patch(`notifications/${notification.id}/read/`);
       }
       if (notification.redirect_url) {
         router.push(notification.redirect_url);
@@ -64,7 +64,7 @@ function NotificationsPageContent() {
 
   const handleReadAll = async () => {
     try {
-      await api.patch("/notifications/read_all/");
+      await api.patch("notifications/read_all/");
       fetchNotifications();
     } catch (err) {
       console.error("전체 읽음 실패", err);

--- a/frontend/src/features/post/components/PostItem.tsx
+++ b/frontend/src/features/post/components/PostItem.tsx
@@ -7,6 +7,7 @@ import Image from "next/image";
 import PostMeta from "./PostMeta";
 import { togglePostLike } from "@/shared/api/community";
 import { AxiosError } from "axios";
+import { API_BASE } from "@/shared/api/api";
 
 interface Props {
   post: Post;
@@ -62,9 +63,6 @@ export default function PostItem({ post }: Props) {
     setLikeCount(post.like_count);
   }, [post.is_liked, post.like_count]);
 
-  const BASE_URL =
-    process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
-
   return (
     <div onClick={handleMoveDetail} className="cursor-pointer">
       <div className="border-b border-[#E5E7EB] py-3">
@@ -86,7 +84,7 @@ export default function PostItem({ post }: Props) {
         {post.thumbnail && (
           <div className="mb-4 rounded-lg overflow-hidden">
             <img
-              src={`${BASE_URL}${post.thumbnail}`}
+              src={`${API_BASE}${post.thumbnail}`}
               alt={post.title}
               width={800}
               height={200}

--- a/frontend/src/features/post/services.ts
+++ b/frontend/src/features/post/services.ts
@@ -1,28 +1,7 @@
+import api from "@/shared/api/axios";
 import { Post } from "./types";
 
-const USE_MOCK = true;
-
-const mockPosts: Post[] = [
-  {
-    id: 1,
-    title: "네이버 AI 공모전 합격 후기",
-    author_name: "김서연",
-    author_id: 3,
-    is_pinned: false,
-    is_anonymous: false,
-    like_count: 12,
-    is_liked: false,
-    comment_count: 4,
-    created_at: "2026-02-01",
-    category: "공지",
-  },
-];
-
 export const fetchPosts = async (): Promise<Post[]> => {
-  if (USE_MOCK) {
-    return mockPosts;
-  }
-
-  // 나중에 API 연결
-  return [];
+  const res = await api.get("community/posts/");
+  return res.data;
 };

--- a/frontend/src/shared/api/announcements.ts
+++ b/frontend/src/shared/api/announcements.ts
@@ -27,7 +27,7 @@ export interface SiteNoticePayload {
   order?: number;
 }
 
-/** 활성 공지/배너 목록 (비인증 가능, 기간·활성 필터 적용) */
+/* 활성 공지/배너 목록 (비인증 가능, 기간·활성 필터 적용) */
 export const getSiteNotices = () =>
   api.get<SiteNoticeItem[]>("announcements/");
 

--- a/frontend/src/shared/api/api.ts
+++ b/frontend/src/shared/api/api.ts
@@ -1,0 +1,3 @@
+export const API_BASE =
+  process.env.NEXT_PUBLIC_API_BASE_URL ??
+  "https://abmproject-production.up.railway.app";

--- a/frontend/src/shared/api/axios.ts
+++ b/frontend/src/shared/api/axios.ts
@@ -1,7 +1,8 @@
 import axios from "axios";
+import { API_BASE } from "./api";
 
 const api = axios.create({
-  baseURL: "http://localhost:8000/api/",
+  baseURL: `${API_BASE}/api/`,
 });
 
 api.interceptors.request.use((config) => {

--- a/frontend/src/shared/api/community.ts
+++ b/frontend/src/shared/api/community.ts
@@ -1,8 +1,6 @@
 import api from "./axios";
 
-/* =======================
-   게시글 목록
-======================= */
+// 게시글 목록 
 export const getPosts = (params?: {
   category?: string;
   ordering?: string;
@@ -11,46 +9,34 @@ export const getPosts = (params?: {
   return api.get("community/posts/", { params });
 };
 
-/* =======================
-   게시글 상세
-======================= */
+// 게시글 상세
 export const getPostDetail = (id: number) => {
   return api.get(`community/posts/${id}/`);
 };
 
-/* =======================
-   게시글 생성
-======================= */
+// 게시글 생성
 export const createPost = (data: FormData) => {
   return api.post("community/posts/", data);
 };
 
-/* =======================
-   좋아요 토글
-======================= */
+// 좋아요 토글
 export const togglePostLike = (id: number) => {
   return api.post(`community/posts/${id}/like/`);
 };
 
-/* =======================
-   카테고리 조회
-======================= */
+// 카테고리 조회
 export const getCategories = (group: string) => {
   return api.get("community/categories/", {
     params: { group },
   });
 };
 
-/* =======================
-   댓글 좋아요
-======================= */
+// 댓글 좋아요
 export const toggleCommentLike = (commentId: number) => {
   return api.post(`community/comments/${commentId}/like/`);
 };
 
-/* =======================
-   댓글 작성
-======================= */
+// 댓글 작성
 export const createComment = (
   postId: number,
   data: { content: string; parent?: number }
@@ -61,16 +47,12 @@ export const createComment = (
   );
 };
 
-/* =======================
-   댓글 삭제
-======================= */
+// 댓글 삭제
 export const deleteComment = (commentId: number) => {
   return api.delete(`community/comments/${commentId}/`);
 };
 
-/* =======================
-   게시글 고정/해제 (관리자 전용)
-======================= */
+// 게시글 고정/해제 (관리자 전용)
 export const pinPost = (id: number) => {
   return api.post(`community/posts/${id}/pin/`);
 };

--- a/frontend/src/shared/api/network.ts
+++ b/frontend/src/shared/api/network.ts
@@ -1,4 +1,3 @@
-// frontend/src/shared/api/network.ts
 import api from "@/shared/api/axios";
 
 export type NetworkType = "student" | "graduate" | "qa";
@@ -73,11 +72,6 @@ export interface Comment {
   like_count: number;
 }
 
-/**
- * ✅ baseURL은 axios.ts에서 이미 "http://localhost:8000/api/" 로 잡혀있음
- * 그래서 여기서는 "networks/..." 처럼 /api/ 없이 상대경로만 쓰면 됨.
- */
-
 export async function fetchCategories(type: NetworkType) {
   const { data } = await api.get<Paginated<Category>>("networks/categories/", {
     params: { type },
@@ -93,9 +87,6 @@ export async function fetchPosts(params: {
   page?: number;
 }): Promise<PostListResponse> {
   const { data } = await api.get("networks/posts/", { params });
-
-  // DRF 전역 pagination 이 적용되면 { count, next, previous, results: { pinned, posts } }
-  // 로 감싸져서 오기 때문에 results 안쪽을 꺼낸다.
   const payload = (data as any).results ?? data;
 
   const rawPinned = payload.pinned;
@@ -155,7 +146,7 @@ export async function unpinPost(id: number) {
   await api.post(`networks/posts/${id}/unpin/`);
 }
 
-/* (선택) 댓글 like / delete도 네가 쓰면 추가 가능
+// 댓글 like / delete도 네가 쓰면 추가 가능
 export async function toggleCommentLike(commentId: number) {
   const { data } = await api.post(`networks/comments/${commentId}/like/`);
   return data;
@@ -164,4 +155,3 @@ export async function toggleCommentLike(commentId: number) {
 export async function deleteComment(commentId: number) {
   await api.delete(`networks/comments/${commentId}/`);
 }
-*/

--- a/frontend/src/shared/components/layout/Header.tsx
+++ b/frontend/src/shared/components/layout/Header.tsx
@@ -15,12 +15,9 @@ export default function Header() {
   // 클라이언트 마운트 후에만 실제 로그인 여부를 반영한다.
   const [isLoggedIn, setIsLoggedIn] = useState(false);
   const [isAdmin, setIsAdmin] = useState(false);
-
-  const [notificationCount, setNotificationCount] = useState(0);
   const { unreadCount, setUnreadCount } = useNotification();
   const [messageCount, setMessageCount] = useState(0);
   
-
   useEffect(() => {
     const token = localStorage.getItem("access_token");
     setIsLoggedIn(!!token);
@@ -31,18 +28,6 @@ export default function Header() {
     }
   }, []);
 
-  useEffect(() => {
-    if (!isLoggedIn) return;
-
-    (async () => {
-      try {
-        const res = await api.get("notifications/unread_count/");
-        setNotificationCount(res.data.unread_count);
-      } catch (err) {
-        console.error("알림 개수 불러오기 실패", err);
-      }
-    })();
-  }, [isLoggedIn]);
 
   useEffect(() => {
     const token = localStorage.getItem("access_token");
@@ -50,7 +35,21 @@ export default function Header() {
 
     (async () => {
       try {
-        const res = await api.get("/messages/messages/unread_count/");
+        const res = await api.get("notifications/unread_count/");
+        setUnreadCount(res.data.unread_count);
+      } catch (err) {
+        console.error(err);
+      }
+    })();
+  }, []);
+
+  useEffect(() => {
+    const token = localStorage.getItem("access_token");
+    if (!token) return;
+
+    (async () => {
+      try {
+        const res = await api.get("messages/messages/unread_count/");
         setMessageCount(res.data.unread_count);
       } catch (err) {
         console.error("쪽지 개수 불러오기 실패", err);
@@ -71,20 +70,6 @@ export default function Header() {
     { name: "네트워크", path: "/network" },
     { name: "커뮤니티", path: "/community" },
   ];
-
-  useEffect(() => {
-    const token = localStorage.getItem("access_token");
-    if (!token) return;
-
-    (async () => {
-      try {
-        const res = await api.get("/notifications/unread_count/");
-        setUnreadCount(res.data.unread_count);
-      } catch (err) {
-        console.error(err);
-      }
-    })();
-  }, []);
 
   return (
     <header className="fixed top-0 left-0 w-full bg-white border-b border-[#E5E7EB] z-50 min-w-[1024px]">
@@ -129,9 +114,9 @@ export default function Header() {
                 onClick={() => router.push("/notifications")}
               >
                 <Bell className="w-6 h-6 text-gray-600" />
-                {notificationCount > 0 && (
+                {unreadCount > 0 && (
                   <span className="absolute -top-2 -right-2 bg-[#FB2C36] text-white text-xs px-1.5 rounded-full">
-                    {notificationCount > 99 ? "99+" : notificationCount}
+                    {unreadCount > 99 ? "99+" : unreadCount}
                   </span>
                 )}
               </div>


### PR DESCRIPTION
## 🔗 관련 이슈
- close #55 

---

## 📌 작업 유형
- [x] FE
- [ ] BE

---

## ✨ 작업 내용
### FE
- API_BASE 환경 변수 적용
API base URL을 api.ts에서 중앙 관리하도록 수정
axios 인스턴스에서 baseURL을 ${API_BASE}/api/ 로 통일

- API 호출 경로 정리
community / network / announcements API 경로 수정
PostItem 썸네일 URL 처리 수정

- 로그인 / 인증 관련 수정
Kakao 로그인 callback API 경로 수정
로그인 / 온보딩 페이지 API 호출 수정

- Header 알림 상태 관리 개선
NotificationContext 기반 unreadCount 사용
중복 notificationCount state 제거

- 기타
서비스 mock 코드 일부 정리
API 호출 구조 통일

---
