### PR TITLE
network_UI & images error

### DIFF
--- a/frontend/src/app/(auth)/login/page.tsx
+++ b/frontend/src/app/(auth)/login/page.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import Logo from "@/shared/components/layout/Logo";
 import{ API_BASE } from "@/shared/api/api";
 
@@ -10,6 +10,13 @@ const KAKAO_REST_KEY = process.env.NEXT_PUBLIC_KAKAO_REST_API_KEY ?? "";
 
 export default function LoginPage() {
   const router = useRouter();
+  const [reason, setReason] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const params = new URLSearchParams(window.location.search);
+    setReason(params.get("reason"));
+  }, []);
   const [showAdmin, setShowAdmin] = useState(false);
   const [adminEmail, setAdminEmail] = useState("");
   const [adminPassword, setAdminPassword] = useState("");
@@ -73,6 +80,11 @@ export default function LoginPage() {
       <div className="mb-5">
         <Logo />
       </div>
+      {reason && (
+        <div className="mb-4 w-full max-w-[460px] bg-blue-50 border border-blue-100 text-sm text-blue-900 px-4 py-3 rounded-xl">
+          더 많은 글을 보고 싶다면 로그인을 해주세요.
+        </div>
+      )}
 
       <h1 className="text-[2rem] font-bold text-gray-900 mb-1.5">로그인</h1>
       <p className="text-gray-500 text-sm mb-8">

--- a/frontend/src/app/community/page.tsx
+++ b/frontend/src/app/community/page.tsx
@@ -48,8 +48,6 @@ export default function CommunityPage() {
     }
   };
 
-  if (!isReady) return null;
-
   return (
     <div className="max-w-3xl mx-auto px-6 pb-10">
       <FilterBar
@@ -64,12 +62,27 @@ export default function CommunityPage() {
       <WriteBox />
 
       <div className="mt-1">
-        {loading ? (
-          <div>로딩중...</div>
+        {!isReady || loading ? (
+          <div className="space-y-4 mt-2">
+            {Array.from({ length: 5 }).map((_, i) => (
+              <div
+                // eslint-disable-next-line react/no-array-index-key
+                key={i}
+                className="animate-pulse rounded-xl border border-gray-100 bg-white p-4"
+              >
+                <div className="h-40 w-full rounded-lg bg-gray-200 mb-4" />
+                <div className="h-4 w-32 bg-gray-200 mb-2 rounded" />
+                <div className="h-5 w-3/4 bg-gray-200 mb-2 rounded" />
+                <div className="h-4 w-1/2 bg-gray-100 rounded" />
+              </div>
+            ))}
+          </div>
+        ) : posts.length === 0 ? (
+          <div className="py-6 text-sm text-gray-500 text-center">
+            아직 작성된 글이 없습니다.
+          </div>
         ) : (
-          posts.map((post) => (
-            <PostItem key={post.id} post={post} />
-          ))
+          posts.map((post) => <PostItem key={post.id} post={post} />)
         )}
       </div>
     </div>

--- a/frontend/src/app/network/page.tsx
+++ b/frontend/src/app/network/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
+import { useRouter } from "next/navigation";
 import {
   fetchCategories,
   fetchPosts,
@@ -8,8 +9,7 @@ import {
   Category,
   PostListItem,
 } from "@/shared/api/network";
-import { useRequireAuth } from "@/shared/hooks/useRequireAuth";
-import Image from "next/image";
+import { Eye, Heart, MessageCircle, Tag } from "lucide-react";
 
 const TABS: { key: NetworkType; label: string }[] = [
   { key: "student", label: "재학생" },
@@ -492,7 +492,8 @@ function formatDotDate(iso?: string) {
 }
 
 export default function NetworkPage() {
-  const { isReady } = useRequireAuth();
+  const router = useRouter();
+  const [isLoggedIn, setIsLoggedIn] = useState(false);
   const [tab, setTab] = useState<NetworkType>("student");
   const [categories, setCategories] = useState<Category[]>([]);
   const [categorySlug, setCategorySlug] = useState<string | undefined>(undefined);
@@ -502,6 +503,12 @@ export default function NetworkPage() {
   const [loading, setLoading] = useState(false);
 
   const [keyword, setKeyword] = useState("");
+
+  useEffect(() => {
+    const token =
+      typeof window !== "undefined" ? localStorage.getItem("access_token") : null;
+    setIsLoggedIn(!!token);
+  }, []);
 
   useEffect(() => {
     (async () => {
@@ -540,7 +547,21 @@ export default function NetworkPage() {
     });
   }, [merged, keyword]);
 
-  if (!isReady) return null;
+  const handleWriteClick = () => {
+    if (!isLoggedIn) {
+      router.push("/login?from=network&reason=write");
+      return;
+    }
+    router.push(`/network/write?type=${tab}`);
+  };
+
+  const handleCardClick = (id: number) => {
+    if (!isLoggedIn) {
+      router.push("/login?from=network&reason=detail");
+      return;
+    }
+    router.push(`/network/${id}`);
+  };
 
   return (
     <div style={{ ...styles.page, marginTop: "-80px" }}>
@@ -617,15 +638,17 @@ export default function NetworkPage() {
                     style={styles.searchInput}
                   />
                 </div>
-                <a
-                  href={`/network/write?type=${tab}`}
+                <button
+                  type="button"
+                  onClick={handleWriteClick}
                   style={{
                     height: 40,
                     padding: "0 18px",
                     borderRadius: 999999,
                     background: "#2563EB",
                     color: "#FFFFFF",
-                    fontFamily: "Inter, system-ui, -apple-system, Segoe UI, Roboto, sans-serif",
+                    fontFamily:
+                      "Inter, system-ui, -apple-system, Segoe UI, Roboto, sans-serif",
                     fontWeight: 600,
                     fontSize: 14,
                     display: "inline-flex",
@@ -634,10 +657,12 @@ export default function NetworkPage() {
                     textDecoration: "none",
                     whiteSpace: "nowrap",
                     boxSizing: "border-box",
+                    border: 0,
+                    cursor: "pointer",
                   }}
                 >
                   + 글쓰기
-                </a>
+                </button>
               </div>
             </div>
           </div>
@@ -646,20 +671,65 @@ export default function NetworkPage() {
         <div style={styles.sectionInner}>
           <div style={styles.gridWrap}>
             {loading ? (
-              <div style={{ padding: "24px 0", color: "#4A5565" }}>로딩중...</div>
+              <div style={styles.grid}>
+                {Array.from({ length: 6 }).map((_, i) => (
+                  // eslint-disable-next-line react/no-array-index-key
+                  <div key={i} style={styles.cardLink}>
+                    <div
+                      style={{
+                        ...styles.cardImage,
+                        background: "#E5E7EB",
+                      }}
+                    />
+                    <div style={styles.cardBody}>
+                      <div
+                        style={{
+                          position: "absolute",
+                          left: 20,
+                          top: 60,
+                          width: 220,
+                          height: 20,
+                          borderRadius: 6,
+                          background: "#E5E7EB",
+                        }}
+                      />
+                      <div
+                        style={{
+                          position: "absolute",
+                          left: 20,
+                          top: 90,
+                          width: 260,
+                          height: 16,
+                          borderRadius: 6,
+                          background: "#F3F4F6",
+                        }}
+                      />
+                      <div
+                        style={{
+                          position: "absolute",
+                          left: 20,
+                          top: 150,
+                          width: 180,
+                          height: 14,
+                          borderRadius: 6,
+                          background: "#E5E7EB",
+                        }}
+                      />
+                    </div>
+                  </div>
+                ))}
+              </div>
             ) : filtered.length === 0 ? (
               <div style={{ padding: "24px 0", color: "#4A5565" }}>게시글이 없습니다.</div>
             ) : (
-              <div style={styles.grid}>
+              <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
                 {filtered.map((p) => {
                   const badgeLabel = p.category_name ?? "전체";
                   const author = p.author_name ?? "-";
                   const date = formatDotDate((p as any).created_at);
                   const views = p.view_count ?? 0;
-                  const comments = (p as any).comment_count ?? 0;
-
-                  const authorInitial =
-                    author && author !== "-" ? author.trim().slice(0, 1) : "?";
+                  const likes = p.like_count ?? 0;
+                  const comments = p.comment_count ?? 0;
 
                   const desc =
                     (p as any).excerpt ??
@@ -668,83 +738,89 @@ export default function NetworkPage() {
                     "";
 
                   return (
-                    <a key={p.id} href={`/network/${p.id}`} style={styles.cardLink}>
-                      {p.thumbnail ? (
-                        // 네트워크 API가 절대 URL을 내려주므로 그대로 사용
-                        // eslint-disable-next-line @next/next/no-img-element
-                        <img
-                          src={p.thumbnail}
-                          alt={p.title}
-                          style={{
-                            ...styles.cardImage,
-                            objectFit: "cover",
-                            display: "block",
-                          }}
-                        />
-                      ) : (
-                        <div style={styles.cardImage} />
-                      )}
-                      <div style={styles.cardBody}>
-                        <div style={{ display: "flex", flexWrap: "wrap", gap: 6, alignItems: "center" }}>
+                    <button
+                      key={p.id}
+                      type="button"
+                      onClick={() => handleCardClick(p.id)}
+                      className="group block bg-white rounded-xl overflow-hidden border border-gray-200 hover:border-[#2563EB] hover:shadow-xl transition-all duration-300 text-left cursor-pointer"
+                    >
+                      {/* 썸네일 */}
+                      <div className="relative w-full h-48 overflow-hidden">
+                        {p.thumbnail ? (
+                          // eslint-disable-next-line @next/next/no-img-element
+                          <img
+                            src={p.thumbnail}
+                            alt={p.title}
+                            loading="lazy"
+                            className="w-full h-full object-cover group-hover:scale-105 transition-transform duration-300"
+                          />
+                        ) : (
+                          <div className="w-full h-full bg-gradient-to-br from-[#D6E4F7] to-[#C5D9F2]" />
+                        )}
+                      </div>
+
+                      {/* 내용 */}
+                      <div className="p-5">
+                        {/* 뱃지 */}
+                        <div className="flex items-center gap-2 mb-3">
                           {p.is_pinned && (
-                            <span
-                              style={{
-                                display: "inline-flex",
-                                alignItems: "center",
-                                gap: 4,
-                                padding: "4px 8px",
-                                borderRadius: 6,
-                                background: "#fffbeb",
-                                color: "#b45309",
-                                fontSize: 12,
-                                fontWeight: 500,
-                              }}
-                            >
+                            <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-md bg-amber-100 text-amber-800 text-xs font-medium">
                               📌 상단 고정
                             </span>
                           )}
-                          <div style={styles.badge}>
-                            <span style={styles.badgeDot} />
-                            <span style={styles.badgeText}>{badgeLabel}</span>
+                          <span className="inline-flex items-center gap-1 px-2.5 py-1 bg-blue-50 text-[#2563EB] rounded-md text-xs font-semibold">
+                            <Tag className="w-3 h-3" />
+                            {badgeLabel}
+                          </span>
+                        </div>
+
+                        {/* 제목 */}
+                        <h3 className="text-lg font-bold mb-2 text-gray-900 line-clamp-2 group-hover:text-[#2563EB] transition-colors">
+                          {p.title}
+                        </h3>
+
+                        {/* 본문 요약 */}
+                        <p className="text-sm text-gray-600 line-clamp-2 mb-4 leading-relaxed">
+                          {desc}
+                        </p>
+
+                        {/* 작성자 / 날짜 */}
+                        <div className="flex items-center gap-2 pt-4 border-t border-gray-100">
+                          {/* eslint-disable-next-line @next/next/no-img-element */}
+                          <img
+                            src={(p as any).author_profile_image || "/icons/userbaseimage.svg"}
+                            alt="profile"
+                            loading="lazy"
+                            className="w-6 h-6 rounded-full object-cover"
+                          />
+                          <div className="text-xs text-gray-600">
+                            <span className="font-medium">{author}</span>
+                            {date && (
+                              <>
+                                <span className="mx-1">·</span>
+                                <span>{date}</span>
+                              </>
+                            )}
                           </div>
                         </div>
 
-                        <h3 style={styles.cardTitle}>{p.title}</h3>
-
-                        <p style={styles.cardDesc}>{desc}</p>
-
-                        <div style={styles.cardFooter}>
-                          <div style={styles.authorLeft}>
-                            <img
-                              src={(p as any).author_profile_image || "/icons/userbaseimage.svg"}
-                              alt="profile"
-                              style={{
-                                width: 24,
-                                height: 24,
-                                borderRadius: "999999px",
-                                objectFit: "cover",
-                              }}
-                            />
-
-                            <div style={styles.authorText}>
-                              {author}
-                              {date ? `·${date}` : ""}
-                            </div>
-                          </div>
-
-                          <div style={styles.stats}>
-                            <div style={styles.stat}>
-                              <Image src="/icons/eye.svg" alt="views" width={14} height={14} />
-                              <span>{views}</span>
-                            </div>
-                            <div style={styles.stat}>
-                              <Image src="/icons/comment.svg" alt="comments" width={14} height={14} />
-                              <span>{comments}</span>
-                            </div>
-                          </div>
+                        {/* 통계 */}
+                        <div className="flex items-center gap-4 mt-3 text-xs text-gray-500">
+                          <span className="flex items-center gap-1">
+                            <Eye className="w-3.5 h-3.5" />
+                            {views}
+                          </span>
+                          <span className="flex items-center gap-1">
+                            <Heart className="w-3.5 h-3.5" />
+                            {likes}
+                          </span>
+                          <span className="flex items-center gap-1">
+                            <MessageCircle className="w-3.5 h-3.5" />
+                            {comments}
+                          </span>
                         </div>
                       </div>
-                    </a>
+                    </button>
                   );
                 })}
               </div>

--- a/frontend/src/features/post/components/PostItem.tsx
+++ b/frontend/src/features/post/components/PostItem.tsx
@@ -7,7 +7,6 @@ import Image from "next/image";
 import PostMeta from "./PostMeta";
 import { togglePostLike } from "@/shared/api/community";
 import { AxiosError } from "axios";
-import { API_BASE } from "@/shared/api/api";
 
 interface Props {
   post: Post;
@@ -84,10 +83,11 @@ export default function PostItem({ post }: Props) {
         {post.thumbnail && (
           <div className="mb-4 rounded-lg overflow-hidden">
             <img
-              src={`${API_BASE}${post.thumbnail}`}
+              src={post.thumbnail}
               alt={post.title}
               width={800}
               height={200}
+              loading="lazy"
               className="w-full object-cover rounded-lg"
             />
           </div>


### PR DESCRIPTION
## 🔗 관련 이슈
- close #85

---

## 📌 작업 유형
- [x] FE
- [ ] BE

---

## ✨ 작업 내용
### FE
- 네트워크 목록 카드 UI를 피그마 시안과 맞게 리디자인
  - 제목 아래 요약 본문 노출
  - 조회수 / 좋아요 / 댓글 수를 아이콘과 함께 표기
  - 카드 사이즈·그리드 레이아웃을 피그마 스타일에 맞게 조정
- 네트워크 / 커뮤니티 목록에 스켈레톤 UI 추가
  - 필터/탭/카테고리 변경 시 “로딩중…” 대신 카드 형태의 스켈레톤 표시
  - `useRequireAuth`에 의한 빈 화면 대신 스켈레톤이 먼저 보이도록 수정
- 네트워크 페이지 접근 권한 UX 개선
  - 네트워크 목록은 비로그인 사용자도 열람 가능하도록 공개
  - 비로그인 상태에서 글쓰기/카드 클릭 시 로그인 페이지로 이동하도록 가드 추가
  - 로그인 페이지 상단에 `더 많은 글을 보고 싶다면 로그인을 해주세요.` 안내 배너 노출 (`reason` 쿼리 기반)
- 이미지 로딩 성능/UX 개선
  - 네트워크/커뮤니티 썸네일 및 프로필 이미지에 `loading="lazy"` 적용

### BE
- 변경 사항 없음

---

## ✅ 체크리스트
- [x] 로컬에서 정상 동작 확인
- [x] 불필요한 코드 제거
- [x] 린트/빌드 통과
- [ ] 리뷰 요청 완료

---

## 📎 추가 자료
- 네트워크 카드 UI 피그마 시안: (필요 시 링크 추가)