### PR TITLE
fix: 0011 migration - StudentRegistry CREATE TABLE IF NOT EXISTS

### DIFF
--- a/backend/apps/users/migrations/0011_add_multi_major_and_student_registry.py
+++ b/backend/apps/users/migrations/0011_add_multi_major_and_student_registry.py
@@ -89,38 +89,56 @@ class Migration(migrations.Migration):
             ],
         ),
         # 재학생 명단 테이블
-        migrations.CreateModel(
-            name="StudentRegistry",
-            fields=[
-                (
-                    "id",
-                    models.BigAutoField(
-                        auto_created=True,
-                        primary_key=True,
-                        serialize=False,
-                        verbose_name="ID",
+        # 프로덕션 DB에 users_studentregistry가 이미 있을 수 있으므로 IF NOT EXISTS 사용
+        migrations.SeparateDatabaseAndState(
+            database_operations=[
+                migrations.RunSQL(
+                    sql=(
+                        'CREATE TABLE IF NOT EXISTS "users_studentregistry" ('
+                        '"id" bigserial NOT NULL PRIMARY KEY, '
+                        '"student_id" varchar(8) NOT NULL UNIQUE, '
+                        '"name" varchar(50) NOT NULL'
+                        ");"
                     ),
-                ),
-                (
-                    "student_id",
-                    models.CharField(
-                        max_length=8,
-                        unique=True,
-                        verbose_name="학번",
-                    ),
-                ),
-                (
-                    "name",
-                    models.CharField(
-                        max_length=50,
-                        verbose_name="이름",
+                    reverse_sql=(
+                        'DROP TABLE IF EXISTS "users_studentregistry";'
                     ),
                 ),
             ],
-            options={
-                "verbose_name": "재학생 명부",
-                "verbose_name_plural": "재학생 명부",
-            },
+            state_operations=[
+                migrations.CreateModel(
+                    name="StudentRegistry",
+                    fields=[
+                        (
+                            "id",
+                            models.BigAutoField(
+                                auto_created=True,
+                                primary_key=True,
+                                serialize=False,
+                                verbose_name="ID",
+                            ),
+                        ),
+                        (
+                            "student_id",
+                            models.CharField(
+                                max_length=8,
+                                unique=True,
+                                verbose_name="학번",
+                            ),
+                        ),
+                        (
+                            "name",
+                            models.CharField(
+                                max_length=50,
+                                verbose_name="이름",
+                            ),
+                        ),
+                    ],
+                    options={
+                        "verbose_name": "재학생 명부",
+                        "verbose_name_plural": "재학생 명부",
+                    },
+                ),
+            ],
         ),
     ]
-


### PR DESCRIPTION
users_studentregistry 테이블이 이미 존재할 경우 DuplicateTable 오류가 발생하던 문제를 SeparateDatabaseAndState + RunSQL(CREATE TABLE IF NOT EXISTS) 로 해결하여 Railway 재배포 시 migrate가 안전하게 완료되도록 수정

Made-with: Cursor

## 🔗 관련 이슈
- close #

---

## 📌 작업 유형
- [ ] FE
- [ ] BE

---

## ✨ 작업 내용
### FE
- (프론트 작업 내용)

### BE
- (백엔드 작업 내용)

---

## ✅ 체크리스트
- [ ] 로컬에서 정상 동작 확인
- [ ] 불필요한 코드 제거
- [ ] 컨벤션 준수
- [ ] 리뷰 요청 완료

---

## 📎 추가 자료 
- 새로 다운받은 것이 있다면 꼭 작성하고, 말해주세요 