### PR TITLE
feat: 프로필 내 글(커뮤니티+네트워크) 연동, 네트워크 이미지/썸네일/글쓰기 개선

### DIFF
--- a/backend/apps/users/views.py
+++ b/backend/apps/users/views.py
@@ -147,24 +147,84 @@ def check_student_id(request):
 
 class MyPostsView(generics.ListAPIView):
     """
-    내가 쓴 글 목록
+    내가 쓴 글 목록 (커뮤니티 + 네트워크 통합)
     GET /api/users/me/posts/
     """
     permission_classes = [permissions.IsAuthenticated]
 
-    def get_queryset(self):
-        from apps.community.models import Post  # type: ignore[reportAttributeAccessIssue]
+    def list(self, request, *args, **kwargs):
+        from django.db.models import Exists, OuterRef
 
-        return (
-            Post.objects  # type: ignore[reportAttributeAccessIssue]
-            .filter(author=self.request.user, is_deleted=False)
+        from apps.community.models import Post as CommunityPost, Reaction
+        from apps.community.serializers import PostListSerializer as CommunityPostListSerializer
+        from apps.networks.models import Post as NetworkPost, Reaction as NetworkReaction
+        from apps.networks.serializers import PostListSerializer as NetworkPostListSerializer
+
+        user = request.user
+
+        # 커뮤니티 글 (is_liked 어노테이션 추가)
+        community_qs = (
+            CommunityPost.objects
+            .filter(author=user, is_deleted=False)
             .select_related("category")
+            .prefetch_related("files")
+            .annotate(
+                is_liked=Exists(
+                    Reaction.objects.filter(
+                        post=OuterRef("pk"),
+                        user=user,
+                    )
+                )
+            )
             .order_by("-created_at")
         )
+        community_serializer = CommunityPostListSerializer(
+            community_qs, many=True, context={"request": request}
+        )
+        community_list = []
+        for i, data in enumerate(community_serializer.data):
+            item = dict(data)
+            item["board_type"] = "community"
+            item["view_count"] = getattr(
+                community_qs[i], "view_count", 0
+            )
+            item["category_name"] = (
+                community_qs[i].category.name
+                if community_qs[i].category
+                else "커뮤니티"
+            )
+            community_list.append(item)
 
-    def get_serializer_class(self):
-        from apps.community.serializers import PostListSerializer
-        return PostListSerializer
+        # 네트워크 글 (is_liked 어노테이션 추가)
+        network_qs = (
+            NetworkPost.objects
+            .filter(author=user, is_deleted=False)
+            .select_related("category")
+            .prefetch_related("files")
+            .annotate(
+                is_liked=Exists(
+                    NetworkReaction.objects.filter(
+                        post=OuterRef("pk"),
+                        user=user,
+                    )
+                )
+            )
+            .order_by("-created_at")
+        )
+        network_serializer = NetworkPostListSerializer(
+            network_qs, many=True, context={"request": request}
+        )
+        network_list = []
+        for data in network_serializer.data:
+            item = dict(data)
+            item["board_type"] = "network"
+            network_list.append(item)
+
+        # 합친 뒤 created_at 기준 최신순
+        merged = community_list + network_list
+        merged.sort(key=lambda x: x.get("created_at") or "", reverse=True)
+
+        return Response(merged)
 
 
 class MyCommentsView(generics.ListAPIView):

--- a/frontend/src/app/(main)/profile/page.tsx
+++ b/frontend/src/app/(main)/profile/page.tsx
@@ -459,19 +459,22 @@ type Tab = "profile" | "activity";
                   <div className="space-y-4">
                     {posts.map((post) => {
                       const created = formatDate(post.created_at);
-                      const category = post.category_name ?? "커뮤니티";
+                      const categoryLabel =
+                        post.board_type === "network"
+                          ? "네트워크"
+                          : (post.category_name ?? "커뮤니티");
                       const views = post.view_count ?? 0;
 
                       return (
                         <div
-                          key={post.id}
+                          key={`${post.board_type ?? "community"}-${post.id}`}
                           className="p-6 border-2 border-gray-200 rounded-2xl hover:bg-gradient-to-br hover:from-blue-50 hover:to-indigo-50 hover:border-[#2563EB] transition-all"
                         >
                           <div className="flex items-start justify-between mb-3">
 
                             <div>
                               <div className="inline-block px-4 py-1 bg-gradient-to-r from-blue-100 to-indigo-100 text-indigo-700 rounded-full text-xs font-bold mb-3">
-                                {category}
+                                {categoryLabel}
                               </div>
 
                               <Link

--- a/frontend/src/app/network/[id]/page.tsx
+++ b/frontend/src/app/network/[id]/page.tsx
@@ -19,7 +19,15 @@ import {
 } from "@/shared/api/network";
 
 import api from "@/shared/api/axios";
+import { API_BASE } from "@/shared/api/api";
 import PostMeta from "@/features/post/components/PostMeta";
+
+function resolveImageUrl(url: string | null | undefined): string {
+  if (!url) return "";
+  if (url.startsWith("http://") || url.startsWith("https://")) return url;
+  const base = API_BASE.replace(/\/$/, "");
+  return url.startsWith("/") ? `${base}${url}` : `${base}/${url}`;
+}
 
 export default function NetworkDetailPage() {
   const { id } = useParams();
@@ -243,10 +251,37 @@ export default function NetworkDetailPage() {
         {post.title}
       </h1>
 
+      {post.thumbnail && (
+        <div className="mb-6 rounded-lg overflow-hidden">
+          <img
+            src={resolveImageUrl(post.thumbnail)}
+            alt="대표 이미지"
+            className="w-full rounded-lg object-cover"
+          />
+        </div>
+      )}
+
       <div
         className="text-[15px] text-[#364153] mb-6 prose max-w-none"
         dangerouslySetInnerHTML={{ __html: post.content }}
       />
+
+      {post.files?.filter((f) => f.file_type === "image").length > 0 && (
+        <div className="space-y-4 mb-6">
+          {post.files
+            .filter((f) => f.file_type === "image")
+            .sort((a, b) => a.order - b.order)
+            .map((file) => (
+              <div key={file.id} className="rounded-lg overflow-hidden">
+                <img
+                  src={resolveImageUrl(file.file)}
+                  alt=""
+                  className="w-full rounded-lg object-contain max-h-[480px]"
+                />
+              </div>
+            ))}
+        </div>
+      )}
 
       <div className="flex justify-end mt-8">
         <button

--- a/frontend/src/app/network/page.tsx
+++ b/frontend/src/app/network/page.tsx
@@ -10,8 +10,16 @@ import {
   Category,
   PostListItem,
 } from "@/shared/api/network";
+import { API_BASE } from "@/shared/api/api";
 import Image from "next/image";
 import { Eye, MessageCircle, Tag } from "lucide-react";
+
+function resolveImageUrl(url: string | null | undefined): string {
+  if (!url) return "";
+  if (url.startsWith("http://") || url.startsWith("https://")) return url;
+  const base = API_BASE.replace(/\/$/, "");
+  return url.startsWith("/") ? `${base}${url}` : `${base}/${url}`;
+}
 
 function toPlainText(input: unknown) {
   if (typeof input !== "string") return "";
@@ -916,21 +924,21 @@ export default function NetworkPage() {
                       onClick={() => handleCardClick(p.id)}
                       className="group block bg-white rounded-xl overflow-hidden border border-gray-200 hover:border-[#2563EB] hover:shadow-xl transition-all duration-300 text-left cursor-pointer"
                     >
-                      {/* 썸네일 */}
+                      {/* 썸네일 - 이미지 1개/여러 개 동일하게 영역 꽉 채움 */}
                       <div
-                        className={`relative w-full aspect-video overflow-hidden${
+                        className={`relative w-full aspect-video overflow-hidden ${
                           !p.thumbnail
-                            ? " bg-gradient-to-br from-[#D6E4F7] to-[#C5D9F2]"
-                            : ""
+                            ? "bg-gradient-to-br from-[#D6E4F7] to-[#C5D9F2]"
+                            : "bg-gray-100"
                         }`}
                       >
                         {p.thumbnail && (
                           // eslint-disable-next-line @next/next/no-img-element
                           <img
-                            src={p.thumbnail}
+                            src={resolveImageUrl(p.thumbnail)}
                             alt={p.title}
                             loading="lazy"
-                            className="absolute inset-0 w-full h-full object-cover group-hover:scale-105 transition-transform duration-300"
+                            className="absolute inset-0 w-full h-full min-w-full min-h-full object-cover object-center group-hover:scale-105 transition-transform duration-300"
                           />
                         )}
                       </div>

--- a/frontend/src/app/network/write_net/page.tsx
+++ b/frontend/src/app/network/write_net/page.tsx
@@ -5,7 +5,7 @@ import { Suspense } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useState, useEffect, useRef } from "react";
 import Image from "next/image";
-import { createPost, fetchCategories } from "@/shared/api/network";
+import { createPost, updatePost, fetchCategories } from "@/shared/api/network";
 
 import { useEditor, EditorContent } from "@tiptap/react";
 import StarterKit from "@tiptap/starter-kit";
@@ -46,6 +46,7 @@ function WriteContent() {
   const [mainImageIndex, setMainImageIndex] = useState<number | null>(null);
 
   const [submitting, setSubmitting] = useState(false);
+  const [isDraggingOver, setIsDraggingOver] = useState(false);
 
   const fileInputRef = useRef<HTMLInputElement | null>(null);
 
@@ -85,29 +86,43 @@ function WriteContent() {
 
   /* ---------------- 이미지 삽입 ---------------- */
 
-  const handleImageUpload = (e: React.ChangeEvent<HTMLInputElement>) => {
+  const addImageFiles = (fileList: FileList | File[]) => {
+    if (!editor) return;
+    const imageFiles = Array.from(fileList).filter((f) =>
+      f.type.startsWith("image/")
+    );
+    if (imageFiles.length === 0) return;
 
-    const files = e.target.files;
-    if (!files || !editor) return;
-
-    Array.from(files).forEach((file) => {
-        const url = URL.createObjectURL(file);
-
-        editor
-            .chain()
-            .focus()
-            .setImage({ src: url })
-            .run();
-
-        setFiles((prev) => [...prev, file]);
-        setPreviewImages((prev) => [...prev, url]);
+    imageFiles.forEach((file) => {
+      const url = URL.createObjectURL(file);
+      editor
+        .chain()
+        .focus()
+        .setImage({ src: url })
+        .run();
+      setFiles((prev) => [...prev, file]);
+      setPreviewImages((prev) => [...prev, url]);
     });
 
     if (mainImageIndex === null) {
       setMainImageIndex(0);
     }
+  };
 
+  const handleImageUpload = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const fileList = e.target.files;
+    if (!fileList) return;
+    addImageFiles(fileList);
     e.target.value = "";
+  };
+
+  const handleImageDrop = (e: React.DragEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    setIsDraggingOver(false);
+    if (!e.dataTransfer.files?.length) return;
+    addImageFiles(e.dataTransfer.files);
+    e.dataTransfer.clearData();
   };
 
   /* ---------------- 카테고리 ---------------- */
@@ -150,15 +165,30 @@ function WriteContent() {
       return;
     }
 
+    // blob URL → 플레이스홀더로 교체 (blob URL 순서 = files 배열 순서)
+    const blobUrls: string[] = [];
+    const PLACEHOLDER_RE = /<img([^>]*?)src="(blob:[^"]+)"([^>]*?)\/?>"/gi;
+    let contentWithPlaceholders = content.replace(
+      /<img([^>]*?)src="(blob:[^"]+)"([^>]*?)\/?>/gi,
+      (_match, before, blobUrl, after) => {
+        const idx = blobUrls.length;
+        blobUrls.push(blobUrl);
+        return `<img${before}src="__BLOB_${idx}__"${after}>`;
+      }
+    );
+    // 실제로 사용한 void reference 방지
+    void PLACEHOLDER_RE;
+
     const formData = new FormData();
 
     formData.append("type", type);
     formData.append("title", title);
-    formData.append("content", content);
+    formData.append("content", contentWithPlaceholders);
     formData.append("is_anonymous", "false");
     formData.append("use_real_name", String(useRealName));
     formData.append("category", category);
 
+    // blob URL 순서와 files 배열 순서가 동일
     files.forEach((file) => {
       formData.append("new_files", file);
     });
@@ -171,7 +201,38 @@ function WriteContent() {
 
       setSubmitting(true);
 
-      await createPost(formData);
+      const created = await createPost(formData);
+
+      // 응답의 files 배열로 플레이스홀더를 실제 URL로 교체 후 PATCH
+      if (blobUrls.length > 0 && created.files && created.files.length > 0) {
+        const imageFiles = created.files
+          .filter((f) => f.file_type === "image")
+          .sort((a, b) => a.order - b.order);
+
+        let fixedContent = contentWithPlaceholders;
+        blobUrls.forEach((_, idx) => {
+          const realUrl = imageFiles[idx]?.file ?? "";
+          fixedContent = fixedContent.replace(
+            `src="__BLOB_${idx}__"`,
+            `src="${realUrl}"`
+          );
+        });
+
+        // 플레이스홀더가 남아있으면(파일 매핑 실패) 제거
+        fixedContent = fixedContent.replace(
+          /<img[^>]*src="__BLOB_\d+__"[^>]*\/?>/gi,
+          ""
+        );
+
+        if (fixedContent !== contentWithPlaceholders) {
+          const patchData = new FormData();
+          patchData.append("content", fixedContent);
+          created.files.forEach((f) => {
+            patchData.append("existing_files", String(f.id));
+          });
+          await updatePost(created.id, patchData);
+        }
+      }
 
       alert("작성 완료");
 
@@ -344,9 +405,22 @@ function WriteContent() {
         className="w-full text-3xl font-normal border-b pb-4 mb-6 outline-none placeholder-gray-300"
       />
 
-      {/* 에디터 */}
-
-      <div className="min-h-[350px] mb-8">
+      {/* 에디터 - 이미지 드래그 앤 드롭 지원 */}
+      <div
+        className={`min-h-[350px] mb-8 rounded-lg border-2 border-dashed transition-colors ${
+          isDraggingOver ? "border-blue-400 bg-blue-50/50" : "border-transparent"
+        }`}
+        onDragOver={(e) => {
+          e.preventDefault();
+          e.stopPropagation();
+          setIsDraggingOver(true);
+        }}
+        onDragLeave={(e) => {
+          e.preventDefault();
+          setIsDraggingOver(false);
+        }}
+        onDrop={handleImageDrop}
+      >
         <EditorContent
           editor={editor}
           className="outline-none w-full prose max-w-none"
@@ -354,7 +428,7 @@ function WriteContent() {
       </div>
 
       {/* 실명 */}
-      <div className="flex items-center gap-2 mt-6 pt-4 pb-6 border-t border-gray-200">
+      <div className="flex items-center gap-2 mt-24 pt-4 pb-6 border-t border-gray-200">
         <input
           type="checkbox"
           id="use-real-name"


### PR DESCRIPTION
- users/views: MyPostsView에 네트워크 글 포함, board_type/category_name 반환
- profile: 네트워크 글 표시 및 '네트워크' 태그, 목록 key 보정
- network/[id]: 상세 페이지 썸네일·첨부 이미지 표시, resolveImageUrl 적용
- network: 목록 썸네일 꽉 채움 및 resolveImageUrl
- write_net: blob URL → 실제 URL PATCH, 이미지 드래그앤드롭, 실명 영역 여백

Made-with: Cursor

## 🔗 관련 이슈
- close #

---

## 📌 작업 유형
- [ ] FE
- [ ] BE

---

## ✨ 작업 내용
### FE
- (프론트 작업 내용)

### BE
- (백엔드 작업 내용)

---

## ✅ 체크리스트
- [ ] 로컬에서 정상 동작 확인
- [ ] 불필요한 코드 제거
- [ ] 컨벤션 준수
- [ ] 리뷰 요청 완료

---

## 📎 추가 자료 
- 새로 다운받은 것이 있다면 꼭 작성하고, 말해주세요 