### PR TITLE
FIX: 로그인 하단, 홈페이지 상단, 알림/메시지, 답글

### DIFF
--- a/frontend/src/app/(auth)/layout.tsx
+++ b/frontend/src/app/(auth)/layout.tsx
@@ -4,11 +4,13 @@ export default function AuthLayout({
   children: React.ReactNode;
 }) {
   return (
-    <div className="relative -mt-20 min-h-screen overflow-hidden bg-gradient-to-br from-[#DBEAFE] via-[#EEF2FF] to-[#EFF6FF] flex flex-col items-center justify-center pt-28 pb-12 px-4">
-      {/* blur circles matching HeroBackground */}
+    <div className="relative -mt-20 min-h-[calc(100vh+80px)] w-full overflow-hidden bg-gradient-to-br from-[#DBEAFE] via-[#EEF2FF] to-[#EFF6FF] flex flex-col items-center justify-center pt-32 pb-20 px-4">
+      {/* 배경 블러 요소들 */}
       <div className="absolute top-0 left-0 w-[358px] h-[358px] bg-[#8EC5FF] rounded-full blur-[128px] opacity-30 pointer-events-none" />
       <div className="absolute top-0 right-0 w-[376px] h-[376px] bg-[#A3B3FF] rounded-full blur-[128px] opacity-30 pointer-events-none" />
       <div className="absolute bottom-0 left-1/2 -translate-x-1/2 w-[414px] h-[414px] bg-[#51A2FF] rounded-full blur-[128px] opacity-30 pointer-events-none" />
+      
+      {/* 실제 컨텐츠 박스 */}
       <div className="relative z-10 w-full flex flex-col items-center">
         {children}
       </div>

--- a/frontend/src/app/(main)/layout.tsx
+++ b/frontend/src/app/(main)/layout.tsx
@@ -6,10 +6,9 @@ export default function MainLayout({
   children: React.ReactNode;
 }) {
   return (
-    <div className="min-h-screen bg-white">
+    <div className="min-h-screen bg-white flex flex-col">
       <Header />
-      <main>{children}</main>
+      <main className="flex-1 pt-20">{children}</main>
     </div>
   );
 }
-

--- a/frontend/src/app/messages/page.tsx
+++ b/frontend/src/app/messages/page.tsx
@@ -245,7 +245,7 @@ function MessagesPageContent(){
   }, []);
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-blue-100 via-indigo-50 to-blue-50 py-6 -mt-20 pt-24">
+    <div className="w-full py-6">
       <div className="max-w-6xl mx-auto w-full px-4 text-left">
         <h1 className="text-2xl font-bold mb-6 text-gray-800 ml-2">메시지</h1>
 

--- a/frontend/src/app/network/[id]/page.tsx
+++ b/frontend/src/app/network/[id]/page.tsx
@@ -291,69 +291,131 @@ export default function NetworkDetailPage() {
         </button>
       </div>
 
-      {/* 댓글 */}
+      {/* 댓글 섹션 시작 */}
       <div className="mt-1 border-t border-[#E5E7EB] pt-5">
         <h3 className="text-[20px] font-semibold mb-5 mt-1">댓글</h3>
 
-        {comments.map((comment) => (
-          <div key={comment.id} className="mb-12">
-            <div className="flex items-start gap-3">
-
-              <div className="w-10 h-10 rounded-full overflow-hidden">
-                <img
-                  src="/icons/userbaseimage.svg"
-                  alt="profile"
-                  className="w-10 h-10 rounded-full"
-                />
-              </div>
-
-              <div className="flex-1">
-
-                <div className="flex items-center gap-2">
-                  <span className="text-[16px] text-[#0A0A0A]">
-                    {comment.is_anonymous ? "익명" : comment.author_name}
-                  </span>
-                  <span className="text-[14px] text-[#6A7282]">
-                    {comment.created_at?.slice(0, 10)}
-                  </span>
+        {comments.length === 0 ? (
+          <div className="py-20 text-center text-[#9CA3AF] text-[14px]">
+            아직 작성된 댓글이 없습니다.
+          </div>
+        ) : (
+          comments.map((comment) => (
+            <div key={comment.id} className="mb-12">
+              <div className="flex items-start gap-3">
+                <div className="w-10 h-10 rounded-full overflow-hidden">
+                  <img
+                    src="/icons/userbaseimage.svg"
+                    alt="profile"
+                    className="w-10 h-10 rounded-full object-cover"
+                  />
                 </div>
 
-                <p className="mt-2 text-[16px] text-[#364153]">
-                  {comment.content}
-                </p>
+                <div className="flex-1">
+                  <div className="flex items-center gap-2">
+                    <span className="text-[16px] text-[#0A0A0A]">
+                      {comment.is_anonymous ? "익명" : comment.author_name}
+                    </span>
+                    <span className="text-[14px] text-[#6A7282]">
+                      {comment.created_at?.slice(0, 10)}
+                    </span>
+                  </div>
 
-                <div className="mt-3 flex items-center gap-3 text-sm text-[#6A7282]">
-                  <button
-                    onClick={() => handleCommentLike(comment.id)}
-                    className="flex items-center gap-1"
-                  >
-                    <Image src="/icons/good.svg" alt="like" width={16} height={16} />
-                    <span>{comment.like_count}</span>
-                  </button>
+                  <p className="mt-2 text-[16px] text-[#364153]">
+                    {comment.content}
+                  </p>
 
-                  <button onClick={() => setReplyOpen(comment.id)}>
-                    답글
-                  </button>
-
-                  {(comment.author_id === currentUserId || isAdmin) && (
-                    <button onClick={() => handleDeleteComment(comment.id)}>
-                      삭제
+                  <div className="mt-3 flex items-center gap-3 text-sm text-[#6A7282]">
+                    <button
+                      onClick={() => handleCommentLike(comment.id)}
+                      className="flex items-center gap-1"
+                    >
+                      <Image src="/icons/good.svg" alt="like" width={16} height={16} />
+                      <span>{comment.like_count}</span>
                     </button>
+
+                    <button onClick={() => setReplyOpen(replyOpen === comment.id ? null : comment.id)}>
+                      답글
+                    </button>
+
+                    {(comment.author_id === currentUserId || isAdmin) && (
+                      <button onClick={() => handleDeleteComment(comment.id)}>
+                        삭제
+                      </button>
+                    )}
+                  </div>
+
+                  {/* 답글(대댓글) 입력창 - 커뮤니티 스타일 */}
+                  {replyOpen === comment.id && (
+                    <div className="mt-4 pl-4 border-l-2 border-[#E5E7EB]">
+                      <textarea
+                        value={replyInput[comment.id] || ""}
+                        onChange={(e) =>
+                          setReplyInput((prev) => ({
+                            ...prev,
+                            [comment.id]: e.target.value,
+                          }))
+                        }
+                        placeholder="답글을 입력하세요..."
+                        className="w-full min-h-[80px] border border-[#E5E7EB] rounded-xl p-3 text-sm focus:outline-none"
+                      />
+                      <div className="flex justify-end mt-2">
+                        <button
+                          onClick={() => handleCreateComment(comment.id)}
+                          disabled={commentSubmitting}
+                          className="px-3 py-1.5 bg-[#2B7FFF] text-white rounded-lg text-xs disabled:opacity-50"
+                        >
+                          {commentSubmitting ? "작성 중..." : "답글 등록"}
+                        </button>
+                      </div>
+                    </div>
+                  )}
+
+                  {/* 대댓글 리스트 렌더링 - 커뮤니티 스타일 */}
+                  {comment.replies && comment.replies.length > 0 && (
+                    <div className="mt-6 ml-10 space-y-6">
+                      {comment.replies.map((reply) => (
+                        <div key={reply.id} className="flex items-start gap-3">
+                          <div className="w-8 h-8 rounded-full overflow-hidden">
+                            <img src="/icons/userbaseimage.svg" alt="profile" className="w-8 h-8 rounded-full" />
+                          </div>
+                          <div className="flex-1">
+                            <div className="flex items-center gap-2">
+                              <span className="text-[14px] font-medium text-[#0A0A0A]">
+                                {reply.is_anonymous ? "익명" : reply.author_name}
+                              </span>
+                              <span className="text-[12px] text-[#6A7282]">
+                                {reply.created_at?.slice(0, 10)}
+                              </span>
+                            </div>
+                            <p className="mt-1 text-[14px] text-[#364153]">{reply.content}</p>
+                            <div className="mt-2 flex gap-3 text-xs text-[#6A7282]">
+                              <button onClick={() => handleCommentLike(reply.id)} className="flex items-center gap-1">
+                                <Image src="/icons/good.svg" alt="like" width={14} height={14} />
+                                <span>{reply.like_count}</span>
+                              </button>
+                              {(reply.author_id === currentUserId || isAdmin) && (
+                                <button onClick={() => handleDeleteComment(reply.id)}>삭제</button>
+                              )}
+                            </div>
+                          </div>
+                        </div>
+                      ))}
+                    </div>
                   )}
                 </div>
-
               </div>
             </div>
-          </div>
-        ))}
+          ))
+        )}
 
-        {/* 댓글 작성 */}
+        {/* 메인 댓글 작성란 */}
         <div className="pt-5 border-t border-[#E5E7EB]">
           <textarea
             value={commentInput}
             onChange={(e) => setCommentInput(e.target.value)}
             placeholder="댓글을 입력하세요..."
-            className="w-full min-h-[160px] border border-[#E5E7EB] rounded-xl p-5 text-[15px]"
+            className="w-full min-h-[160px] border border-[#E5E7EB] rounded-xl p-5 text-[15px] focus:outline-none focus:ring-1 focus:ring-[#2B7FFF] mt-5"
           />
 
           <div className="flex justify-between items-center mt-5">
@@ -370,13 +432,12 @@ export default function NetworkDetailPage() {
             <button
               onClick={() => handleCreateComment(null)}
               disabled={commentSubmitting}
-              className="px-4 py-2 bg-[#2B7FFF] text-white rounded-lg text-sm"
+              className="px-4 py-2 bg-[#2B7FFF] text-white rounded-lg text-sm disabled:opacity-50"
             >
               {commentSubmitting ? "작성 중..." : "댓글 작성"}
             </button>
           </div>
         </div>
-
       </div>
 
     </div>

--- a/frontend/src/app/notifications/page.tsx
+++ b/frontend/src/app/notifications/page.tsx
@@ -87,7 +87,7 @@ function NotificationsPageContent() {
     );
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-blue-100 via-indigo-50 to-blue-50 w-full py-6">
+    <div className="w-full py-6">
       <div className="max-w-5xl mx-auto w-full px-4 text-left">
         <div className="flex justify-between items-end mb-6">
           <h1 className="text-4xl font-bold text-gray-900">알림</h1>


### PR DESCRIPTION
## 🔗 관련 이슈
- close #135

---

## 📌 작업 유형
- [x] FE
- [ ] BE

---

## ✨ 작업 내용
### FE
- 로그인 페이지 하당 공백 제거 
- 홈페이지 상단 공백 추가
- 알림/ 메시지 페이지 뒤에 네모 박스제거 
- 답글 로직 변경 
