### PR TITLE
fix(network): author 중복 전달로 인한 게시물 작성 에러 수정

### DIFF
--- a/backend/apps/networks/serializers.py
+++ b/backend/apps/networks/serializers.py
@@ -336,9 +336,8 @@ class PostCreateSerializer(serializers.ModelSerializer):
     def create(self, validated_data):
         new_files = validated_data.pop("new_files", [])
         thumbnail_index = validated_data.pop("thumbnail_index", None)
-        user = self.context["request"].user
 
-        post = Post.objects.create(author=user, **validated_data)
+        post = Post.objects.create(**validated_data)
 
         image_files = []
         for index, file in enumerate(new_files):


### PR DESCRIPTION
perform_create에서 save(author=...)로 이미 전달하는데
serializer.create에서도 author=user를 명시적으로 넘겨 TypeError 발생

Made-with: Cursor

## 🔗 관련 이슈
- close #

---

## 📌 작업 유형
- [ ] FE
- [ ] BE

---

## ✨ 작업 내용
### FE
- (프론트 작업 내용)

### BE
- (백엔드 작업 내용)

---

## ✅ 체크리스트
- [ ] 로컬에서 정상 동작 확인
- [ ] 불필요한 코드 제거
- [ ] 컨벤션 준수
- [ ] 리뷰 요청 완료

---

## 📎 추가 자료 
- 새로 다운받은 것이 있다면 꼭 작성하고, 말해주세요 