### PR TITLE
FIX: route edit back button to list

### DIFF
--- a/frontend/src/app/network/edit/[id]/page.tsx
+++ b/frontend/src/app/network/edit/[id]/page.tsx
@@ -371,7 +371,7 @@ function EditContent() {
         <div className="max-w-4xl mx-auto w-full px-6">
           <div className="flex items-center justify-between py-2.5">
             <div className="flex items-center gap-3">
-              <button onClick={() => router.back()}>
+              <button onClick={() => router.push(`/network?type=${postType}`)}>
                 <Image src="/icons/back.svg" alt="back" width={22} height={22} />
               </button>
               <span className="text-lg font-semibold">네트워크 글 수정</span>


### PR DESCRIPTION
Avoid router.back() so returning from edit always lands on network list.

Made-with: Cursor

## 🔗 관련 이슈
- close #

---

## 📌 작업 유형
- [ ] FE
- [ ] BE

---

## ✨ 작업 내용
### FE
- (프론트 작업 내용)

### BE
- (백엔드 작업 내용)

---

## ✅ 체크리스트
- [ ] 로컬에서 정상 동작 확인
- [ ] 불필요한 코드 제거
- [ ] 컨벤션 준수
- [ ] 리뷰 요청 완료

---

## 📎 추가 자료 
- 새로 다운받은 것이 있다면 꼭 작성하고, 말해주세요 