### PR TITLE
FIX: 이미지 처리 수정

### DIFF
--- a/backend/apps/networks/serializers.py
+++ b/backend/apps/networks/serializers.py
@@ -357,6 +357,14 @@ class PostCreateSerializer(serializers.ModelSerializer):
                 post__isnull=True
             ).update(post=post)
 
+            # order 재정렬 (임시저장 시 order=0으로 고정돼 있어서)
+            existing_files_qs = post.files.filter(
+                id__in=existing_file_ids
+            ).order_by("id")
+            for i, pf in enumerate(existing_files_qs):
+                pf.order = i
+                pf.save(update_fields=["order"])
+
         image_files = []
         for index, file in enumerate(new_files):
             content_type = getattr(file, "content_type", "")
@@ -462,14 +470,11 @@ class PostCreateSerializer(serializers.ModelSerializer):
             post_file.delete()
 
         if new_files:
-            current_count = instance.files.count()
+            current_count = PostFile.objects.filter(post=instance).count()
 
             for index, file in enumerate(new_files):
                 content_type = getattr(file, "content_type", "")
-                file_type = (
-                    "image" if content_type.startswith("image/") else "pdf"
-                )
-
+                file_type = "image" if content_type.startswith("image/") else "pdf"
                 PostFile.objects.create(
                     post=instance,
                     file=file,
@@ -477,7 +482,38 @@ class PostCreateSerializer(serializers.ModelSerializer):
                     order=current_count + index,
                 )
 
-        image_files = list(instance.files.filter(file_type="image"))
+            # content placeholder 치환도 같은 블록 안에서
+            if instance.content:
+                request = self.context.get("request")
+                fixed_content = instance.content
+
+                new_image_files = list(
+                    instance.files
+                    .filter(file_type="image", order__gte=current_count)
+                    .order_by("order")
+                )
+
+                for i, file_obj in enumerate(new_image_files):
+                    if not file_obj.file:
+                        continue
+                    url = file_obj.file.url
+                    if not str(url).startswith(("http://", "https://")) and request:
+                        url = request.build_absolute_uri(url)
+                    placeholder = f'src="__BLOB_{i}__"'
+                    fixed_content = fixed_content.replace(placeholder, f'src="{url}"')
+
+                fixed_content = re.sub(
+                    r'<img[^>]*src="__BLOB_\d+__"[^>]*\/?>',
+                    "",
+                    fixed_content,
+                    flags=re.IGNORECASE,
+                )
+
+                if fixed_content != instance.content:
+                    instance.content = fixed_content
+                    instance.save(update_fields=["content"])
+
+        image_files = list(instance.files.filter(file_type="image").order_by("order"))
         should_regenerate_thumbnail = (
             thumbnail_index is not None
             or bool(files_to_delete)

--- a/frontend/src/app/network/edit/[id]/page.tsx
+++ b/frontend/src/app/network/edit/[id]/page.tsx
@@ -171,8 +171,6 @@ function EditContent() {
     (async () => {
       try {
         const post = await fetchPostDetail(postId);
-        console.log("post.files:", post.files);      // ← 추가
-        console.log("post.thumbnail:", post.thumbnail);
         setTitle(post.title);
         setPostType(post.type);
         setIsAnonymous(post.is_anonymous);
@@ -299,8 +297,13 @@ function EditContent() {
       formData.append("use_real_name", String(useRealName));
       formData.append("category", category);
 
-      // 3) 유지할 기존 이미지 id (삭제된 것은 제외됨)
-      existingImages.forEach((img) => formData.append("existing_files", String(img.id)));
+      // 3) 유지할 기존 이미지 id 빈 배열이어도 명시적으로 전송
+      if (existingImages.length > 0) {
+        existingImages.forEach((img) => formData.append("existing_files", String(img.id)));
+      } else {
+        // 기존 이미지 전부 삭제된 경우 → clear_files로 명시
+        formData.append("clear_files", "true");
+      }
 
       // 4) 새 이미지: HTML 등장 순서대로 (순서 버그 핵심 수정)
       orderedBlobUrls.forEach((blobUrl) => {
@@ -308,48 +311,29 @@ function EditContent() {
         if (file) formData.append("new_files", file);
       });
 
-      // 5) 썸네일 인덱스 전송 (이미지들: 기존 이미지들 + 새 이미지들 순서 기준)
-      const thumbnailChanged = thumbnailSrc !== initialThumbnailSrc;
+      // 5) 썸네일 인덱스 전송 
       if (thumbnailSrc) {
         const existingIdx = existingImages.findIndex((img) => img.url === thumbnailSrc);
         if (existingIdx !== -1) {
+          // 기존 이미지가 썸네일
           formData.append("thumbnail_index", String(existingIdx));
         } else {
-          const newIdx = orderedBlobUrls.indexOf(thumbnailSrc);
+          // 새 이미지가 썸네일 — orderedBlobUrls 우선, 없으면 newImages 기준으로 fallback
+          let newIdx = orderedBlobUrls.indexOf(thumbnailSrc);
+          if (newIdx === -1) {
+            // thumbnailSrc가 content에 없는 경우 (onUpdate 타이밍 이슈) → newImages 기준
+            newIdx = newImages.findIndex((img) => img.url === thumbnailSrc);
+          }
           if (newIdx !== -1) {
             formData.append("thumbnail_index", String(existingImages.length + newIdx));
+          } else if (orderedBlobUrls.length > 0) {
+            // 그래도 못 찾으면 새 이미지 첫 번째를 썸네일로
+            formData.append("thumbnail_index", String(existingImages.length));
           }
         }
       }
 
       const updated = await updatePost(postId, formData);
-
-      // 6) 업로드된 새 이미지 URL 로 __BLOB_N__ 치환 (2차 patch)
-      if (orderedBlobUrls.length > 0 && updated.files?.length) {
-        const base = API_BASE.replace(/\/$/, "");
-        const existingIds = new Set(existingImages.map((img) => img.id));
-        const uploadedFiles = updated.files
-          .filter((f: { file_type: string }) => f.file_type === "image")
-          .filter((f: { id: number }) => !existingIds.has(f.id))
-          .sort((a: { order: number }, b: { order: number }) => a.order - b.order);
-
-        let fixedContent = contentToSave;
-        orderedBlobUrls.forEach((_, idx) => {
-          const raw = uploadedFiles[idx]?.file ?? "";
-          const realUrl = raw
-            ? raw.startsWith("http://") || raw.startsWith("https://") ? raw : `${base}${raw.startsWith("/") ? raw : `/${raw}`}`
-            : "";
-          fixedContent = fixedContent.replace(`src="__BLOB_${idx}__"`, `src="${realUrl}"`);
-        });
-        fixedContent = fixedContent.replace(/<img[^>]*src="__BLOB_\d+__"[^>]*\/?>/gi, "");
-
-        if (fixedContent !== contentToSave) {
-          const patchData = new FormData();
-          patchData.append("content", fixedContent);
-          updated.files.forEach((f: { id: number }) => patchData.append("existing_files", String(f.id)));
-          await updatePost(postId, patchData);
-        }
-      }
 
       alert("수정 완료");
       router.push(`/network?type=${postType}`);

--- a/frontend/src/app/network/write_net/page.tsx
+++ b/frontend/src/app/network/write_net/page.tsx
@@ -133,6 +133,7 @@ function WriteContent() {
   const draftCheckedRef = useRef(false);
   const justSavedRef = useRef(false);
   const autoSaveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const isInternalUpdateRef = useRef(false);
 
   // onDelete는 ref로 들고 있어서 에디터 재생성 없이 항상 최신 콜백 유지
   const onDeleteRef = useRef<(src: string) => void>(() => {});
@@ -185,6 +186,11 @@ function WriteContent() {
       const html = e.getHTML();
       setContent(html);
       setIsDirty(true);
+
+      if (isInternalUpdateRef.current) {
+        isInternalUpdateRef.current = false;
+        return;
+      }
 
       // 에디터에서 이미지가 직접 삭제/이동될 수 있으므로 상태를 HTML 기준으로 동기화
       const orderedSrcs = extractImageSrcs(html);
@@ -319,12 +325,21 @@ function WriteContent() {
               const result = await uploadDraftImage(file);
               blobToUrl.set(blobUrl, result.url);
               uploadedIds.push(result.id);
-              // newImages 업데이트
-              setNewImages((prev) => prev.map((img) =>
-                img.url === blobUrl ? { ...img, url: result.url, postFileId: result.id } : img
-              ));
             })
           );
+
+          // newImages 한번에 업데이트
+          setNewImages((prev) => prev.map((img) => {
+            const newUrl = blobToUrl.get(img.url);
+            if (!newUrl) return img;
+            const id = uploadedIds[blobUrls.indexOf(img.url)];
+            return { ...img, url: newUrl, postFileId: id };
+          }));
+
+          setMainImageUrl((prev) => {
+            if (!prev) return prev;
+            return blobToUrl.get(prev) ?? prev;
+          });
 
           savedContent = content.replace(
             /<img([^>]*?)src="(blob:[^"]+)"([^>]*?)\/?>/gi,
@@ -334,10 +349,10 @@ function WriteContent() {
             }
           );
 
-          // 에디터 content도 업데이트
-          if (editor) editor.commands.setContent(savedContent);
-          setContent(savedContent);
-        }
+          isInternalUpdateRef.current = true;
+            if (editor) editor.commands.setContent(savedContent);
+            setContent(savedContent);
+          }
 
         const existingIds = newImages
           .filter((img) => img.postFileId)


### PR DESCRIPTION
## 🔗 관련 이슈
- close #302

---

## 📌 작업 유형
- [x] FE
- [x] BE

---

## 문제 원인

**1. 글 수정 시 새 이미지 404 (핵심)**
`edit` 페이지에서 수정 저장 시 `updatePost()`를 2번 호출하는 로직이 있었는데, 2차 호출 시 백엔드 `update()`가 재실행되면서 `existing_files` 기준으로 일부 `PostFile`이 삭제되고 R2에서도 파일이 제거되어 404 발생.

**2. 기존 이미지 전부 삭제가 안 되는 문제**
기존 이미지를 전부 삭제했을 때 `existing_files`가 FormData에 아예 안 들어가면, 백엔드에서 "변경 없음"으로 처리하여 기존 파일이 삭제되지 않음.

**3. `update()` 내 `__BLOB_N__` 치환 누락**
`create()`에는 placeholder 치환 로직이 있었지만 `update()`에는 없어서, 수정 시 새로 올린 이미지의 placeholder가 content에 그대로 남아 이미지가 노출되지 않음.

**4. `current_count` Django ORM 캐시 문제**
`files_to_delete` 삭제 후 `instance.files.count()`를 호출할 때 캐시로 인해 삭제 전 count가 반환되어 새 파일의 `order`가 잘못 계산됨. 이로 인해 일부 수정 시나리오에서 동일한 이미지가 중복 노출.

**5. 임시저장 이미지 `order` 중복**
`ImageUploadView`에서 임시저장 이미지를 `order=0`으로 고정 저장하여, 2장 이상 올리면 모두 `order=0`이 되고 `create()` 시 `__BLOB_1__` 이후 치환 실패.

**6. 자동저장 시 `newImages` 초기화**
자동저장 중 blob → 서버 URL 교체 후 `editor.commands.setContent()` 호출 시 `onUpdate`가 트리거되어 `newImages`를 HTML 기준으로 동기화하는데, 이미 URL이 서버 URL로 바뀐 상태라 blob URL 기반의 `newImages`가 전부 제거됨.

---

## 변경 사항

### `serializers.py`
- `update()`에 `__BLOB_N__` → 실제 R2 URL 치환 로직 추가 (`create()`와 동일)
- `update()` 내 `current_count`를 `PostFile.objects.filter(post=instance).count()`로 변경하여 ORM 캐시 우회
- `update()` 내 `image_files` 쿼리에 `.order_by("order")` 추가
- `create()` 내 임시저장 이미지 연결 후 `order` 재정렬 로직 추가

### `edit/[id]/page.tsx`
- `handleSubmit` 내 2차 `updatePost()` 호출 블록 전체 제거
- 기존 이미지 전부 삭제 시 `existing_files` 대신 `clear_files: true` 전송하도록 수정
- 썸네일 인덱스 계산 시 `newImages` 기준 fallback 추가

### `write_net/page.tsx`
- `isInternalUpdateRef` 추가하여 자동저장 시 `onUpdate`의 `newImages` 동기화 차단
- 자동저장 완료 후 `setNewImages`, `setMainImageUrl`을 먼저 업데이트한 뒤 에디터 content 교체하도록 순서 변경
- `Promise.all` 안의 개별 `setNewImages` 호출 제거 → 완료 후 한 번에 업데이트로 변경

---

## 테스트 시나리오

- [x] 이미지 없이 글 작성
- [x] 이미지 2장으로 글 작성 후 두 번째 이미지 썸네일 지정
- [x] 자동저장 후 완료 시 이미지/썸네일 정상 유지
- [x] 임시저장 후 복원하여 글 작성 완료
- [x] 텍스트만 수정 시 기존 이미지/썸네일 유지
- [x] 기존 이미지 전부 삭제 후 새 이미지 추가
- [x] 기존 이미지 일부 교체
- [x] 썸네일만 변경
- [x] 기존 이미지 일부 교체 + 교체한 이미지로 썸네일 변경 (`current_count` 캐시 수정으로 해결 예정)