### PR TITLE
FIX: 로그인 token처리

### DIFF
--- a/frontend/src/app/(auth)/login/kakao-callback/page.tsx
+++ b/frontend/src/app/(auth)/login/kakao-callback/page.tsx
@@ -8,6 +8,7 @@ import {
   API_BASE,
   ONBOARDING_SIGNUP_STORAGE_KEY,
   ONBOARDING_NONCE_STORAGE_KEY,
+  TokenStorage,
 } from "@/shared/api/api";
 
 
@@ -76,6 +77,9 @@ function KakaoCallbackContent() {
           return;
         }
 
+        if (data.tokens?.access && data.tokens?.refresh) {
+          TokenStorage.set(data.tokens.access, data.tokens.refresh);
+        }
         if (data.user?.id) {
           localStorage.setItem("user_id", String(data.user.id));
         }

--- a/frontend/src/shared/api/api.ts
+++ b/frontend/src/shared/api/api.ts
@@ -6,3 +6,35 @@ export const ONBOARDING_SIGNUP_STORAGE_KEY = "onboarding_signup_token";
 
 /** 더블 서브밋 CSRF 방어 — 백엔드가 내려준 nonce 보관 */
 export const ONBOARDING_NONCE_STORAGE_KEY = "onboarding_nonce";
+
+// ── JWT 토큰 헬퍼 ──────────────────────────────────────────
+export const TokenStorage = {
+  getAccess: () => localStorage.getItem("access_token"),
+  getRefresh: () => localStorage.getItem("refresh_token"),
+  set: (access: string, refresh: string) => {
+    localStorage.setItem("access_token", access);
+    localStorage.setItem("refresh_token", refresh);
+  },
+  clear: () => {
+    localStorage.removeItem("access_token");
+    localStorage.removeItem("refresh_token");
+    localStorage.removeItem("user_id");
+  },
+};
+
+// ── 인증 헤더 포함 fetch 래퍼 ──────────────────────────────
+export async function apiFetch(
+  input: RequestInfo,
+  init: RequestInit = {}
+): Promise<Response> {
+  const token = TokenStorage.getAccess();
+  return fetch(input, {
+    ...init,
+    credentials: "include",
+    headers: {
+      "Content-Type": "application/json",
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+      ...(init.headers ?? {}),
+    },
+  });
+}

--- a/frontend/src/shared/api/axios.ts
+++ b/frontend/src/shared/api/axios.ts
@@ -1,18 +1,25 @@
 import axios from "axios";
-import { API_BASE } from "./api";
+import { API_BASE, TokenStorage } from "./api";
 
 const api = axios.create({
   baseURL: `${API_BASE}/api/`,
   withCredentials: true,
 });
 
+// 요청마다 Authorization 헤더 자동 주입
+api.interceptors.request.use((config) => {
+  const token = TokenStorage.getAccess();
+  if (token) {
+    config.headers.Authorization = `Bearer ${token}`;
+  }
+  return config;
+});
+
 api.interceptors.response.use(
   (response) => response,
   (error) => {
-    // users/me/는 각 컴포넌트에서 직접 처리하므로 여기서 redirect 안 함
     if (error.response?.status === 401) {
-      localStorage.removeItem("user_id");
-      // useRequireAuth나 각 페이지에서 처리하도록 그냥 reject만
+      TokenStorage.clear(); // user_id 포함 전부 삭제
     }
     return Promise.reject(error);
   }

--- a/frontend/src/shared/components/layout/Header.tsx
+++ b/frontend/src/shared/components/layout/Header.tsx
@@ -5,6 +5,7 @@ import { useRouter, usePathname } from "next/navigation";
 import { useEffect, useState } from "react";
 import { Mail, Bell, LayoutDashboard } from "lucide-react";
 import api from "@/shared/api/axios";
+import { TokenStorage } from "@/shared/api/api";
 import { useNotification } from "@/shared/contexts/NotificationContext";
 import Logo from "@/shared/components/layout/Logo";
 
@@ -39,10 +40,9 @@ export default function Header() {
   }, [setUnreadCount]);
 
   const handleLogout = async () => {
-    // 쿠키 삭제는 백엔드가 처리
-    await api.post("users/logout/").catch(() => {});
-    // user_id만 정리
-    localStorage.removeItem("user_id");
+    const refresh = TokenStorage.getRefresh();
+    await api.post("users/logout/", { refresh }).catch(() => {});
+    TokenStorage.clear(); // access_token, refresh_token, user_id 모두 삭제
     setIsLoggedIn(false);
     setIsAdmin(false);
     setUnreadCount(0);


### PR DESCRIPTION
## 🔗 관련 이슈
- close #400

---

## 📌 작업 유형
- [x] FE
- [ ] BE

---

## ✨ 작업 내용
### FE
- shared/api/api.ts — TokenStorage, apiFetch 헬퍼 추가
- kakao-callback/page.tsx — 로그인 성공 시 TokenStorage.set()으로 access/refresh 토큰 localStorage 저장
- shared/api/axios.ts — request interceptor 추가로 모든 API 요청에 Authorization 헤더 자동 주입 / 401 응답 시 TokenStorage.clear()로 토큰 전체 삭제
- Header.tsx — 로그아웃 시 TokenStorage.clear()로 토큰 전체 삭제

---
