### PR TITLE
FIX:OTP 인증 변경

### DIFF
--- a/backend/apps/users/otp_email.py
+++ b/backend/apps/users/otp_email.py
@@ -1,37 +1,25 @@
-"""관리자 OTP 메일 — SendGrid HTTP API (SMTP send_mail보다 지연·타임아웃 이슈가 적음)."""
-
 import logging
-import os
-
+from django.core.mail import send_mail
 from django.conf import settings
-from sendgrid import SendGridAPIClient
-from sendgrid.helpers.mail import Mail
 
 logger = logging.getLogger(__name__)
 
 
 def send_admin_otp_email(to_email: str, otp_code: str, subject: str) -> bool:
-    """
-    SendGrid v3 API로 OTP 발송. 성공 시 True, 실패 시 False (예외는 잡고 로깅).
-    """
-    api_key = os.environ.get("SENDGRID_API_KEY")
-    if not api_key:
-        logger.error("send_admin_otp_email: SENDGRID_API_KEY not set")
-        return False
     if not (to_email or "").strip():
         logger.error("send_admin_otp_email: empty recipient")
         return False
 
     body = f"인증번호: {otp_code}\n5분 내로 입력해주세요."
     try:
-        message = Mail(
-            from_email=settings.DEFAULT_FROM_EMAIL,
-            to_emails=to_email.strip(),
+        send_mail(
             subject=subject,
-            plain_text_content=body,
+            message=body,
+            from_email=settings.DEFAULT_FROM_EMAIL,
+            recipient_list=[to_email.strip()],
+            fail_silently=False,
         )
-        SendGridAPIClient(api_key).send(message)
         return True
     except Exception:
-        logger.exception("send_admin_otp_email: SendGrid send failed")
+        logger.exception("send_admin_otp_email: Gmail send failed")
         return False

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -354,13 +354,14 @@ SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
 # 관리자 계정 보안 설정 
 # ==================== 이메일 설정 ====================
 EMAIL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"
-EMAIL_HOST = "smtp.sendgrid.net"
+EMAIL_HOST = "smtp.gmail.com"
 EMAIL_PORT = 587
 EMAIL_USE_TLS = True
 EMAIL_USE_SSL = False
-EMAIL_HOST_USER = "apikey"
-EMAIL_HOST_PASSWORD = os.environ.get("SENDGRID_API_KEY", "")
-DEFAULT_FROM_EMAIL = "aive.admin@gmail.com"
+EMAIL_HOST_USER = os.environ.get("EMAIL_HOST_USER", "")
+EMAIL_HOST_PASSWORD = os.environ.get("EMAIL_HOST_PASSWORD", "")
+DEFAULT_FROM_EMAIL = os.environ.get("EMAIL_HOST_USER", "")
+EMAIL_TIMEOUT = 10
 
 # ==================== 보안 설정 ====================
 if not DEBUG:


### PR DESCRIPTION
## 🔗 관련 이슈
- close #402

---

## 📌 작업 유형
- [ ] FE
- [x] BE

---

## ✨ 작업 내용
### FE
- (프론트 작업 내용)

### BE
백엔드
apps/users/otp_email.py - SendGrid HTTP API → Django 기본 send_mail (Gmail SMTP)로 교체
config/settings.py - 이메일 설정을 SendGrid SMTP → Gmail SMTP로 변경

Railway 환경변수

EMAIL_HOST_USER = aive.admin@gmail.com
EMAIL_HOST_PASSWORD = Gmail 앱 비밀번호 16자리
SENDGRID_API_KEY 불필요 (삭제 가능)

