### PR TITLE
feat: Admin 분석 탭 기간(start_date/end_date) 선택

### DIFF
--- a/backend/logs/views.py
+++ b/backend/logs/views.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from collections import defaultdict
+from datetime import date
 
 from django.db.models import Avg, Case, Count, IntegerField, Min, Max, Sum, When
 from rest_framework.permissions import AllowAny, IsAdminUser
@@ -81,32 +82,126 @@ def _weight_annotation() -> Case:
     return Case(*whens, default=0, output_field=IntegerField())
 
 
+def _parse_analytics_period(request: Request) -> tuple:
+    """
+    start_date/end_date(YYYY-MM-DD, inclusive) 우선.
+    없으면 days=1|7|30… (기본 1=오늘, 롤링 N일).
+    반환: (start_date|None, end_date|None, days|None)
+    """
+    from django.utils.dateparse import parse_date
+
+    start_s = (request.query_params.get("start_date") or "").strip()
+    end_s = (request.query_params.get("end_date") or "").strip()
+    if start_s and end_s:
+        start = parse_date(start_s)
+        end = parse_date(end_s)
+        if start and end:
+            if start > end:
+                start, end = end, start
+            return start, end, None
+
+    days_param = request.query_params.get("days", "1")
+    try:
+        days = max(1, min(90, int(days_param)))
+    except (ValueError, TypeError):
+        days = 1
+    return None, None, days
+
+
+def _parse_analytics_period_optional(request: Request) -> tuple:
+    """days/start_date 생략 시 전 기간(None). 대시보드 KPI 외 차트용."""
+    from django.utils.dateparse import parse_date
+
+    start_s = (request.query_params.get("start_date") or "").strip()
+    end_s = (request.query_params.get("end_date") or "").strip()
+    if start_s and end_s:
+        start = parse_date(start_s)
+        end = parse_date(end_s)
+        if start and end:
+            if start > end:
+                start, end = end, start
+            return start, end, None
+
+    days_param = request.query_params.get("days")
+    if days_param:
+        try:
+            days = max(1, min(90, int(days_param)))
+            return None, None, days
+        except (ValueError, TypeError):
+            pass
+    return None, None, None
+
+
+def _period_response_meta(
+    start_date: date | None, end_date: date | None, days: int | None
+) -> dict[str, object]:
+    if start_date and end_date:
+        return {
+            "start_date": start_date.isoformat(),
+            "end_date": end_date.isoformat(),
+        }
+    return {"days": days}
+
+
+def _resolve_analytics_period(
+    request: Request, default_days: int | None = None
+) -> tuple:
+    """optional 파싱 + default_days(예: post-segment 30일)."""
+    start_date, end_date, days = _parse_analytics_period_optional(request)
+    if start_date is None and end_date is None and days is None and default_days is not None:
+        days = default_days
+    return start_date, end_date, days
+
+
+def _filter_eventlog_by_period(qs, start_date, end_date, days):
+    from datetime import timedelta
+
+    if start_date and end_date:
+        return qs.filter(
+            created_at__date__gte=start_date,
+            created_at__date__lte=end_date,
+        )
+    if days == 1:
+        return qs.filter(created_at__date=timezone.localdate())
+    if days is not None:
+        since = timezone.now() - timedelta(days=days)
+        return qs.filter(created_at__gte=since)
+    return qs
+
+
+def _filter_created_at_by_period(qs, start_date, end_date, days):
+    from datetime import timedelta
+
+    if start_date and end_date:
+        return qs.filter(
+            created_at__date__gte=start_date,
+            created_at__date__lte=end_date,
+        )
+    if days == 1:
+        return qs.filter(created_at__date=timezone.localdate())
+    if days is not None:
+        since = timezone.now() - timedelta(days=days)
+        return qs.filter(created_at__gte=since)
+    return qs
+
+
 # ---------------------------------------------------------------------------
 # 0. 대시보드 KPI (기간별 집계)
-#    GET /api/logs/analytics/dashboard-kpi/?days=1|7|30 (기본 1=오늘)
+#    GET /api/logs/analytics/dashboard-kpi/?days=1|7|30
+#    GET /api/logs/analytics/dashboard-kpi/?start_date=2026-05-01&end_date=2026-05-07
 # ---------------------------------------------------------------------------
 class DashboardKpiView(APIView):
     """
     대시보드 상단 KPI: 로그인, 신규 가입, 작성된 글, 댓글, 검색 수.
-    쿼리 days=1(오늘), 7(지난 7일), 30(지난 30일). 기본 1.
+    쿼리 days=1(오늘), 7, 30 또는 start_date/end_date(달력 기간, inclusive).
     """
     permission_classes = [IsAdminUser]
 
     def get(self, request: Request) -> Response:
-        from datetime import timedelta
-
-        days_param = request.query_params.get("days", "1")
-        try:
-            days = max(1, min(90, int(days_param)))
-        except (ValueError, TypeError):
-            days = 1
-
-        if days == 1:
-            today = timezone.localdate()
-            qs = EventLog.objects.filter(created_at__date=today)
-        else:
-            since = timezone.now() - timedelta(days=days)
-            qs = EventLog.objects.filter(created_at__gte=since)
+        start_date, end_date, days = _parse_analytics_period(request)
+        qs = _filter_eventlog_by_period(
+            EventLog.objects.all(), start_date, end_date, days
+        )
 
         unique_visitors = (
             qs.filter(
@@ -138,7 +233,7 @@ class DashboardKpiView(APIView):
             "engagements": engagements,
             "engagement_rate": engagement_rate,
             "unique_visitors": unique_visitors,
-            "days": days,
+            **_period_response_meta(start_date, end_date, days),
         })
 
 
@@ -224,9 +319,14 @@ class HeatmapView(APIView):
     permission_classes = [IsAdminUser]
 
     def get(self, request: Request) -> Response:
+        start_date, end_date, days = _resolve_analytics_period(request)
         rows = (
-            EventLog.objects
-            .filter(event_type__in=INTERACTION_EVENT_TYPES)
+            _filter_eventlog_by_period(
+                EventLog.objects.filter(event_type__in=INTERACTION_EVENT_TYPES),
+                start_date,
+                end_date,
+                days,
+            )
             .annotate(weight=_weight_annotation())
             .values(
                 "author_grade_at_event",
@@ -306,12 +406,14 @@ class PopularByGradeView(APIView):
             top_n = 5
 
         rows = (
-            EventLog.objects
-            .filter(
-                event_type__in=INTERACTION_EVENT_TYPES,
-                grade_at_event__in=GRADES,
-                post_id__isnull=False,
-                section__in=("community", "network"),
+            _filter_eventlog_by_period(
+                EventLog.objects.filter(
+                    event_type__in=INTERACTION_EVENT_TYPES,
+                    grade_at_event__in=GRADES,
+                    post_id__isnull=False,
+                    section__in=("community", "network"),
+                ),
+                *_resolve_analytics_period(request),
             )
             .values("grade_at_event", "section", "post_id")
             .annotate(score=Sum(_weight_annotation()))
@@ -396,8 +498,6 @@ class PopularByInterestView(APIView):
     permission_classes = [IsAdminUser]
 
     def get(self, request: Request) -> Response:
-        from datetime import timedelta
-
         section = request.query_params.get("section", "network").strip()
         if section not in ("community", "network"):
             section = "network"
@@ -407,20 +507,18 @@ class PopularByInterestView(APIView):
         except (ValueError, TypeError):
             top_n = 5
 
-        days_param = request.query_params.get("days")
-        qs = EventLog.objects.filter(
-            event_type="post_view",
-            section=section,
-            post_id__isnull=False,
-            interest_at_event__in=ALLOWED_INTERESTS,
+        start_date, end_date, days = _resolve_analytics_period(request)
+        qs = _filter_eventlog_by_period(
+            EventLog.objects.filter(
+                event_type="post_view",
+                section=section,
+                post_id__isnull=False,
+                interest_at_event__in=ALLOWED_INTERESTS,
+            ),
+            start_date,
+            end_date,
+            days,
         )
-        if days_param is not None:
-            try:
-                days = max(1, min(int(days_param), 90))
-                since = timezone.now() - timedelta(days=days)
-                qs = qs.filter(created_at__gte=since)
-            except (ValueError, TypeError):
-                pass
 
         rows = (
             qs.values("interest_at_event", "post_id")
@@ -495,8 +593,6 @@ class PostSegmentViewsView(APIView):
     permission_classes = [IsAdminUser]
 
     def get(self, request: Request) -> Response:
-        from datetime import timedelta
-
         section = request.query_params.get("section", "network").strip()
         if section not in ("community", "network"):
             section = "network"
@@ -511,22 +607,18 @@ class PostSegmentViewsView(APIView):
         except (ValueError, TypeError):
             top_segments = 3
 
-        days = 30
-        days_param = request.query_params.get("days")
-        if days_param is not None:
-            try:
-                days = max(1, min(int(days_param), 90))
-            except (ValueError, TypeError):
-                days = 30
-
-        since = timezone.now() - timedelta(days=days)
-        qs = EventLog.objects.filter(
-            event_type="post_view",
-            section=section,
-            post_id__isnull=False,
-            interest_at_event__in=ALLOWED_INTERESTS,
-            grade_at_event__in=GRADES,
-            created_at__gte=since,
+        start_date, end_date, days = _resolve_analytics_period(request, default_days=30)
+        qs = _filter_eventlog_by_period(
+            EventLog.objects.filter(
+                event_type="post_view",
+                section=section,
+                post_id__isnull=False,
+                interest_at_event__in=ALLOWED_INTERESTS,
+                grade_at_event__in=GRADES,
+            ),
+            start_date,
+            end_date,
+            days,
         )
 
         rows = (
@@ -554,7 +646,7 @@ class PostSegmentViewsView(APIView):
         if not by_post:
             return Response({
                 "section": section,
-                "days": days,
+                **_period_response_meta(start_date, end_date, days),
                 "posts": [],
             })
 
@@ -611,7 +703,7 @@ class PostSegmentViewsView(APIView):
 
         return Response({
             "section": section,
-            "days": days,
+            **_period_response_meta(start_date, end_date, days),
             "posts": posts_result,
         })
 
@@ -638,10 +730,16 @@ class SearchRankingView(APIView):
         section = request.query_params.get("section")
         interest_param = request.query_params.get("interest")
 
-        qs = EventLog.objects.filter(
-            event_type="search",
-            search_keyword__isnull=False,
-        ).exclude(search_keyword="")
+        start_date, end_date, days = _resolve_analytics_period(request)
+        qs = _filter_eventlog_by_period(
+            EventLog.objects.filter(
+                event_type="search",
+                search_keyword__isnull=False,
+            ).exclude(search_keyword=""),
+            start_date,
+            end_date,
+            days,
+        )
 
         if section:
             qs = qs.filter(section=section)
@@ -771,21 +869,17 @@ class PageVisitorsView(APIView):
     permission_classes = [IsAdminUser]
 
     def get(self, request: Request) -> Response:
-        from datetime import timedelta
-
         order = ["community", "department", "network", "home"]
-        qs = EventLog.objects.filter(
-            event_type="page_view",
-            section__in=order,
+        start_date, end_date, days = _parse_analytics_period_optional(request)
+        qs = _filter_eventlog_by_period(
+            EventLog.objects.filter(
+                event_type="page_view",
+                section__in=order,
+            ),
+            start_date,
+            end_date,
+            days,
         )
-        days_param = request.query_params.get("days")
-        if days_param:
-            try:
-                days = max(1, min(90, int(days_param)))
-                since = timezone.now() - timedelta(days=days)
-                qs = qs.filter(created_at__gte=since)
-            except (ValueError, TypeError):
-                pass
 
         rows = qs.values("section").annotate(count=Count("id"))
         by_section = {r["section"]: r["count"] for r in rows}
@@ -821,20 +915,16 @@ class SessionStatsView(APIView):
     permission_classes = [IsAdminUser]
 
     def get(self, request: Request) -> Response:
-        from datetime import timedelta
-
-        qs = (
-            EventLog.objects
-            .filter(event_type="page_view", session_id__isnull=False)
-            .exclude(session_id="")
+        start_date, end_date, days = _resolve_analytics_period(request)
+        qs = _filter_eventlog_by_period(
+            EventLog.objects.filter(
+                event_type="page_view",
+                session_id__isnull=False,
+            ).exclude(session_id=""),
+            start_date,
+            end_date,
+            days,
         )
-        days_param = request.query_params.get("days")
-        if days_param:
-            try:
-                since = timezone.now() - timedelta(days=int(days_param))
-                qs = qs.filter(created_at__gte=since)
-            except (ValueError, TypeError):
-                pass
 
         rows = list(
             qs.values("session_id").annotate(
@@ -890,22 +980,18 @@ class SessionAnalyticsView(APIView):
     ]
 
     def get(self, request: Request) -> Response:
-        from datetime import timedelta
-
-        qs = (
-            EventLog.objects
-            .filter(event_type="page_view", session_id__isnull=False)
-            .exclude(session_id="")
-            .values("session_id", "created_at", "grade_at_event", "user_type")
-            .order_by("session_id", "created_at")
+        start_date, end_date, days = _resolve_analytics_period(request)
+        qs = _filter_eventlog_by_period(
+            EventLog.objects.filter(
+                event_type="page_view",
+                session_id__isnull=False,
+            ).exclude(session_id=""),
+            start_date,
+            end_date,
+            days,
+        ).values("session_id", "created_at", "grade_at_event", "user_type").order_by(
+            "session_id", "created_at"
         )
-        days_param = request.query_params.get("days")
-        if days_param:
-            try:
-                since = timezone.now() - timedelta(days=int(days_param))
-                qs = qs.filter(created_at__gte=since)
-            except (ValueError, TypeError):
-                pass
 
         rows = list(qs)
         # 세션별 그룹: { session_id: [ (created_at, grade_at_event, user_type), ... ] }
@@ -990,20 +1076,11 @@ class KnowledgeDeliveryScoreView(APIView):
     permission_classes = [IsAdminUser]
 
     def get(self, request: Request) -> Response:
-        from datetime import timedelta
-
         from apps.users.models import User
         from apps.community.models import Post as CPost, Comment as CComment
         from apps.networks.models import Post as NPost, Comment as NComment
 
-        since = None
-        days_param = request.query_params.get("days")
-        if days_param:
-            try:
-                days = max(1, min(90, int(days_param)))
-                since = timezone.now() - timedelta(days=days)
-            except (ValueError, TypeError):
-                pass
+        start_date, end_date, days = _parse_analytics_period_optional(request)
 
         # 졸업생 가입자가 실제로 존재하는지 확인
         has_graduate_users = User.objects.filter(user_type="graduate").exists()
@@ -1037,11 +1114,10 @@ class KnowledgeDeliveryScoreView(APIView):
         n_post_qs = NPost.objects.filter(is_deleted=False)
         c_comment_qs = CComment.objects.filter(is_deleted=False)
         n_comment_qs = NComment.objects.filter(is_deleted=False)
-        if since is not None:
-            c_post_qs = c_post_qs.filter(created_at__gte=since)
-            n_post_qs = n_post_qs.filter(created_at__gte=since)
-            c_comment_qs = c_comment_qs.filter(created_at__gte=since)
-            n_comment_qs = n_comment_qs.filter(created_at__gte=since)
+        c_post_qs = _filter_created_at_by_period(c_post_qs, start_date, end_date, days)
+        n_post_qs = _filter_created_at_by_period(n_post_qs, start_date, end_date, days)
+        c_comment_qs = _filter_created_at_by_period(c_comment_qs, start_date, end_date, days)
+        n_comment_qs = _filter_created_at_by_period(n_comment_qs, start_date, end_date, days)
 
         # P, L 기본치: Post/Comment 테이블 기준
         for row in c_post_qs.values("author_id", "like_count"):
@@ -1078,8 +1154,9 @@ class KnowledgeDeliveryScoreView(APIView):
             author_grade_at_event__in=GRADES,
             grade_at_event__in=GRADES,
         )
-        if since is not None:
-            like_log_qs = like_log_qs.filter(created_at__gte=since)
+        like_log_qs = _filter_eventlog_by_period(
+            like_log_qs, start_date, end_date, days
+        )
         for row in like_log_qs.values("author_grade_at_event", "grade_at_event"):
             author_g = row["author_grade_at_event"]
             consumer_g = row["grade_at_event"]
@@ -1100,8 +1177,9 @@ class KnowledgeDeliveryScoreView(APIView):
             author_grade_at_event__in=GRADES,
             grade_at_event__in=GRADES,
         )
-        if since is not None:
-            comment_log_qs = comment_log_qs.filter(created_at__gte=since)
+        comment_log_qs = _filter_eventlog_by_period(
+            comment_log_qs, start_date, end_date, days
+        )
         for row in comment_log_qs.values("author_grade_at_event", "grade_at_event"):
             author_g = row["author_grade_at_event"]
             consumer_g = row["grade_at_event"]
@@ -1334,16 +1412,18 @@ class SessionJourneyView(APIView):
         except (ValueError, TypeError):
             top_n = 15
 
-        # session_id 있고 section 있는 page_view 로그만
-        qs = (
-            EventLog.objects
-            .filter(
+        start_date, end_date, days = _resolve_analytics_period(request)
+        qs = _filter_eventlog_by_period(
+            EventLog.objects.filter(
                 event_type="page_view",
                 session_id__isnull=False,
                 section__isnull=False,
-            )
-            .values("session_id", "section", "created_at")
-            .order_by("session_id", "created_at")
+            ),
+            start_date,
+            end_date,
+            days,
+        ).values("session_id", "section", "created_at").order_by(
+            "session_id", "created_at"
         )
 
         # 세션별로 섹션 순서 묶기 → 전환 쌍(from→to) 카운트
@@ -1379,8 +1459,15 @@ class SessionJourneyView(APIView):
 
         # 섹션별 방문 빈도 (여정맵 보조 정보)
         section_visits = (
-            EventLog.objects
-            .filter(event_type="page_view", section__isnull=False)
+            _filter_eventlog_by_period(
+                EventLog.objects.filter(
+                    event_type="page_view",
+                    section__isnull=False,
+                ),
+                start_date,
+                end_date,
+                days,
+            )
             .values("section")
             .annotate(visits=Count("id"))
             .order_by("-visits")

--- a/frontend/src/app/admin/page.tsx
+++ b/frontend/src/app/admin/page.tsx
@@ -104,6 +104,89 @@ type ViewType =
   | "sessions"
   | "announcements";
 
+function formatLocalDate(d: Date): string {
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  return `${y}-${m}-${day}`;
+}
+
+function dashboardPresetRange(preset: 1 | 7 | 30): { start: string; end: string } {
+  const end = new Date();
+  const start = new Date();
+  if (preset > 1) {
+    start.setDate(start.getDate() - (preset - 1));
+  }
+  return { start: formatLocalDate(start), end: formatLocalDate(end) };
+}
+
+type AdminPeriodPreset = 1 | 7 | 30 | "custom";
+
+function toPeriodParams(startDate: string, endDate: string) {
+  return { start_date: startDate, end_date: endDate };
+}
+
+function PeriodRangeControls({
+  preset,
+  startDate,
+  endDate,
+  onPreset,
+  onStartDateChange,
+  onEndDateChange,
+}: {
+  preset: AdminPeriodPreset;
+  startDate: string;
+  endDate: string;
+  onPreset: (preset: 1 | 7 | 30) => void;
+  onStartDateChange: (value: string) => void;
+  onEndDateChange: (value: string) => void;
+}) {
+  return (
+    <div className="flex flex-wrap items-center gap-2">
+      <div className="flex items-center gap-1 rounded-xl border border-gray-200 p-1 bg-white">
+        {([1, 7, 30] as const).map((d) => (
+          <button
+            key={d}
+            type="button"
+            onClick={() => onPreset(d)}
+            className={`px-3 py-1.5 rounded-lg text-sm font-medium transition-colors ${
+              preset === d
+                ? "bg-[#2563EB] text-white"
+                : "text-gray-600 hover:bg-gray-100"
+            }`}
+          >
+            {d === 1 ? "오늘" : d === 7 ? "7일" : "30일"}
+          </button>
+        ))}
+      </div>
+      <div className="flex items-center gap-2 rounded-xl border border-gray-200 bg-white px-3 py-1.5">
+        <label className="flex items-center gap-1.5 text-sm text-gray-600">
+          <span className="sr-only">시작일</span>
+          <input
+            type="date"
+            value={startDate}
+            max={endDate}
+            onChange={(e) => onStartDateChange(e.target.value)}
+            className="rounded-lg border-0 bg-transparent text-sm text-gray-900 focus:ring-2 focus:ring-[#2563EB] p-0"
+          />
+        </label>
+        <span className="text-gray-400 text-sm">~</span>
+        <label className="flex items-center gap-1.5 text-sm text-gray-600">
+          <span className="sr-only">종료일</span>
+          <input
+            type="date"
+            value={endDate}
+            min={startDate}
+            max={formatLocalDate(new Date())}
+            onChange={(e) => onEndDateChange(e.target.value)}
+            className="rounded-lg border-0 bg-transparent text-sm text-gray-900 focus:ring-2 focus:ring-[#2563EB] p-0"
+          />
+        </label>
+      </div>
+    </div>
+  );
+}
+
 // 이벤트 상세 패널용 타입 (EventDetailPanel에서 사용)
 interface OperationalLog {
   id: number;
@@ -397,7 +480,25 @@ export default function AdminPage() {
   const [notificationToCurrentList, setNotificationToCurrentList] = useState(false);
   const [notificationSending, setNotificationSending] = useState(false);
   const [notificationError, setNotificationError] = useState("");
-  const [dashboardDays, setDashboardDays] = useState<1 | 7 | 30>(1);
+  const [dashboardPreset, setDashboardPreset] = useState<1 | 7 | 30 | "custom">(1);
+  const [dashboardStartDate, setDashboardStartDate] = useState(
+    () => dashboardPresetRange(1).start
+  );
+  const [dashboardEndDate, setDashboardEndDate] = useState(
+    () => dashboardPresetRange(1).end
+  );
+  const defaultAnalyticsRange = dashboardPresetRange(30);
+  const [analyticsPreset, setAnalyticsPreset] = useState<AdminPeriodPreset>(30);
+  const [analyticsStartDate, setAnalyticsStartDate] = useState(defaultAnalyticsRange.start);
+  const [analyticsEndDate, setAnalyticsEndDate] = useState(defaultAnalyticsRange.end);
+  const defaultSessionsRange = dashboardPresetRange(30);
+  const [sessionsPreset, setSessionsPreset] = useState<AdminPeriodPreset>(30);
+  const [sessionsStartDate, setSessionsStartDate] = useState(defaultSessionsRange.start);
+  const [sessionsEndDate, setSessionsEndDate] = useState(defaultSessionsRange.end);
+  const defaultSearchRange = dashboardPresetRange(30);
+  const [searchPreset, setSearchPreset] = useState<AdminPeriodPreset>(30);
+  const [searchStartDate, setSearchStartDate] = useState(defaultSearchRange.start);
+  const [searchEndDate, setSearchEndDate] = useState(defaultSearchRange.end);
   const [siteNotices, setSiteNotices] = useState<SiteNoticeItem[]>([]);
   const [loadingSiteNotices, setLoadingSiteNotices] = useState(false);
   const [noticeModalOpen, setNoticeModalOpen] = useState(false);
@@ -452,17 +553,19 @@ export default function AdminPage() {
   // 행동 분석
   useEffect(() => {
     if (!isAdmin || currentView !== "analytics") return;
+    if (!analyticsStartDate || !analyticsEndDate) return;
     setLoadingAnalytics(true);
+    const periodParams = toPeriodParams(analyticsStartDate, analyticsEndDate);
     Promise.all([
-      getHeatmap().then((r) => r.data.rows),
-      getPageVisitors({ days: 30 }).then((r) => r.data.by_section),
-      getKnowledgeDeliveryScore({ days: 30 }).then((r) => r.data.by_grade),
-      getPopularByGrade({ top_n: 5 }).then((r) => r.data.by_grade),
+      getHeatmap(periodParams).then((r) => r.data.rows),
+      getPageVisitors(periodParams).then((r) => r.data.by_section),
+      getKnowledgeDeliveryScore(periodParams).then((r) => r.data.by_grade),
+      getPopularByGrade({ top_n: 5, ...periodParams }).then((r) => r.data.by_grade),
       getPostSegmentViews({
         section: "network",
         top_posts: 10,
         top_segments: 3,
-        days: 30,
+        ...periodParams,
       }).then((r) => r.data.posts),
     ])
       .then(([rows, bySection, byGrade, popular, segmentPosts]) => {
@@ -475,7 +578,7 @@ export default function AdminPage() {
       })
       .catch(() => {})
       .finally(() => setLoadingAnalytics(false));
-  }, [isAdmin, currentView]);
+  }, [isAdmin, currentView, analyticsStartDate, analyticsEndDate]);
 
   // 에러 모니터링
   useEffect(() => {
@@ -526,29 +629,32 @@ export default function AdminPage() {
   // 검색 분석
   useEffect(() => {
     if (!isAdmin || currentView !== "searchAnalytics") return;
+    if (!searchStartDate || !searchEndDate) return;
     setLoadingSearch(true);
     const interest = searchInterestFilter === "all" ? undefined : searchInterestFilter === "AI" ? "ai" : searchInterestFilter === "데이터" ? "data" : "business";
-    getSearchRanking({ top_n: 10, interest })
+    getSearchRanking({ top_n: 10, interest, ...toPeriodParams(searchStartDate, searchEndDate) })
       .then((r) => {
         setSearchTotal(r.data.total_search_count);
         setSearchRanking(r.data.ranking);
       })
       .catch(() => {})
       .finally(() => setLoadingSearch(false));
-  }, [isAdmin, currentView, searchInterestFilter]);
+  }, [isAdmin, currentView, searchInterestFilter, searchStartDate, searchEndDate]);
 
   // 세션 분석
   useEffect(() => {
     if (!isAdmin || currentView !== "sessions") return;
+    if (!sessionsStartDate || !sessionsEndDate) return;
     setLoadingSession(true);
     setLoadingSessionAnalytics(true);
-    getSessionStats({ days: 30 })
+    const periodParams = toPeriodParams(sessionsStartDate, sessionsEndDate);
+    getSessionStats(periodParams)
       .then((r) => setSessionStats(r.data))
       .catch(() => {})
       .finally(() => setLoadingSession(false));
     Promise.all([
-      getSessionAnalytics({ days: 30 }),
-      getSessionJourney({ top_n: 10 }),
+      getSessionAnalytics(periodParams),
+      getSessionJourney({ top_n: 10, ...periodParams }),
     ])
       .then(([analyticsRes, journeyRes]) => {
         setSessionByGrade(analyticsRes.data.by_grade);
@@ -557,17 +663,18 @@ export default function AdminPage() {
       })
       .catch(() => {})
       .finally(() => setLoadingSessionAnalytics(false));
-  }, [isAdmin, currentView]);
+  }, [isAdmin, currentView, sessionsStartDate, sessionsEndDate]);
 
   // 대시보드 KPI + 페이지방문 + 지식전달
   useEffect(() => {
     if (!isAdmin || currentView !== "dashboard") return;
+    if (!dashboardStartDate || !dashboardEndDate) return;
     setLoadingDashboardKpi(true);
-    const days = dashboardDays;
+    const periodParams = toPeriodParams(dashboardStartDate, dashboardEndDate);
     Promise.all([
-      getDashboardKpi({ days }).then((r) => r.data),
-      getPageVisitors({ days }).then((r) => r.data.by_section),
-      getKnowledgeDeliveryScore({ days }).then((r) => r.data.by_grade),
+      getDashboardKpi(periodParams).then((r) => r.data),
+      getPageVisitors(periodParams).then((r) => r.data.by_section),
+      getKnowledgeDeliveryScore(periodParams).then((r) => r.data.by_grade),
     ])
       .then(([kpi, bySection, byGrade]) => {
         setDashboardKpi(kpi);
@@ -576,7 +683,7 @@ export default function AdminPage() {
       })
       .catch(() => setDashboardKpi(null))
       .finally(() => setLoadingDashboardKpi(false));
-  }, [isAdmin, currentView, dashboardDays]);
+  }, [isAdmin, currentView, dashboardStartDate, dashboardEndDate]);
 
   // 운영 로그 목록 (event_type: all->빈값, post->post_create)
   const operationalEventType =
@@ -724,7 +831,7 @@ export default function AdminPage() {
   };
 
   const handleExportCsv = () => {
-    const periodLabel = dashboardDays === 1 ? "오늘" : dashboardDays === 7 ? "지난 7일" : "지난 30일";
+    const periodLabel = `${dashboardStartDate} ~ ${dashboardEndDate}`;
     const rows: string[][] = [
       ["AIVE 대시보드 내보내기", ""],
       ["기간", periodLabel],
@@ -766,7 +873,7 @@ export default function AdminPage() {
     const url = URL.createObjectURL(blob);
     const a = document.createElement("a");
     a.href = url;
-    a.download = `aive-dashboard-${dashboardDays}days-${new Date().toISOString().slice(0, 10)}.csv`;
+    a.download = `aive-dashboard-${dashboardStartDate}_${dashboardEndDate}.csv`;
     a.click();
     URL.revokeObjectURL(url);
   };
@@ -925,32 +1032,38 @@ export default function AdminPage() {
           {/* ── 대시보드 ── */}
           {currentView === "dashboard" && (
             <>
-              <div className="mb-8 flex items-center justify-between">
+              <div className="mb-8 flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
                 <div>
                   <h1 className="text-3xl font-bold text-gray-900 mb-2">대시보드</h1>
                   <p className="text-gray-600">UGC·참여·검색·세션 KPI (EventLog 집계)</p>
+                  <p className="text-sm text-gray-500 mt-1">
+                    집계 기간: {dashboardStartDate} ~ {dashboardEndDate}
+                  </p>
                 </div>
-                <div className="flex items-center gap-3">
-                  <div className="flex items-center gap-1 rounded-xl border border-gray-200 p-1 bg-white">
-                    {([1, 7, 30] as const).map((d) => (
-                      <button
-                        key={d}
-                        type="button"
-                        onClick={() => setDashboardDays(d)}
-                        className={`px-3 py-1.5 rounded-lg text-sm font-medium transition-colors ${
-                          dashboardDays === d
-                            ? "bg-[#2563EB] text-white"
-                            : "text-gray-600 hover:bg-gray-100"
-                        }`}
-                      >
-                        {d === 1 ? "오늘" : d === 7 ? "지난 7일" : "지난 30일"}
-                      </button>
-                    ))}
-                  </div>
+                <div className="flex flex-col items-stretch sm:items-end gap-3">
+                  <PeriodRangeControls
+                    preset={dashboardPreset}
+                    startDate={dashboardStartDate}
+                    endDate={dashboardEndDate}
+                    onPreset={(d) => {
+                      const range = dashboardPresetRange(d);
+                      setDashboardPreset(d);
+                      setDashboardStartDate(range.start);
+                      setDashboardEndDate(range.end);
+                    }}
+                    onStartDateChange={(v) => {
+                      setDashboardStartDate(v);
+                      setDashboardPreset("custom");
+                    }}
+                    onEndDateChange={(v) => {
+                      setDashboardEndDate(v);
+                      setDashboardPreset("custom");
+                    }}
+                  />
                   <button
                     type="button"
                     onClick={handleExportCsv}
-                    className="flex items-center gap-2 px-4 py-2 bg-gradient-to-r from-[#2563EB] to-[#8B5CF6] text-white rounded-xl hover:shadow-lg transition-all"
+                    className="flex items-center justify-center gap-2 px-4 py-2 bg-gradient-to-r from-[#2563EB] to-[#8B5CF6] text-white rounded-xl hover:shadow-lg transition-all self-end"
                   >
                     <Download className="w-4 h-4" />
                     <span className="text-sm font-semibold">Export CSV</span>
@@ -966,8 +1079,8 @@ export default function AdminPage() {
                 ) : (
                   [
                     { label: "순 방문자", value: dashboardKpi?.unique_visitors ?? 0, suffix: "", icon: Eye, color: "bg-cyan-100", iconColor: "text-cyan-600" },
-                    { label: dashboardDays === 1 ? "로그인" : "로그인", value: dashboardKpi?.today_logins ?? 0, suffix: "", icon: LogIn, color: "bg-blue-100", iconColor: "text-blue-600" },
-                    { label: dashboardDays === 1 ? "신규 가입" : "가입", value: dashboardKpi?.today_signups ?? 0, suffix: "", icon: UserPlus, color: "bg-green-100", iconColor: "text-green-600" },
+                    { label: "로그인", value: dashboardKpi?.today_logins ?? 0, suffix: "", icon: LogIn, color: "bg-blue-100", iconColor: "text-blue-600" },
+                    { label: dashboardStartDate === dashboardEndDate ? "신규 가입" : "가입", value: dashboardKpi?.today_signups ?? 0, suffix: "", icon: UserPlus, color: "bg-green-100", iconColor: "text-green-600" },
                     { label: "검색", value: dashboardKpi?.today_searches ?? 0, suffix: "", icon: Search, color: "bg-pink-100", iconColor: "text-pink-600" },
                     { label: "게시글 조회", value: dashboardKpi?.post_views ?? 0, suffix: "", icon: Eye, color: "bg-indigo-100", iconColor: "text-indigo-600" },
                     { label: "참여율", value: dashboardKpi?.engagement_rate ?? 0, suffix: "%", icon: TrendingUp, color: "bg-amber-100", iconColor: "text-amber-600", sub: `좋아요+댓글 ${dashboardKpi?.engagements ?? 0}건` },
@@ -1148,11 +1261,33 @@ export default function AdminPage() {
           {/* ── 행동 분석 ── */}
           {currentView === "analytics" && (
             <>
-              <div className="mb-8 flex items-center justify-between">
+              <div className="mb-8 flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
                 <div>
                   <h1 className="text-3xl font-bold text-gray-900 mb-2">행동 분석: 학년 간 연결성</h1>
                   <p className="text-gray-600">학년 간 상호작용 및 지식 전달 패턴</p>
+                  <p className="text-sm text-gray-500 mt-1">
+                    집계 기간: {analyticsStartDate} ~ {analyticsEndDate}
+                  </p>
                 </div>
+                <PeriodRangeControls
+                  preset={analyticsPreset}
+                  startDate={analyticsStartDate}
+                  endDate={analyticsEndDate}
+                  onPreset={(d) => {
+                    const range = dashboardPresetRange(d);
+                    setAnalyticsPreset(d);
+                    setAnalyticsStartDate(range.start);
+                    setAnalyticsEndDate(range.end);
+                  }}
+                  onStartDateChange={(v) => {
+                    setAnalyticsStartDate(v);
+                    setAnalyticsPreset("custom");
+                  }}
+                  onEndDateChange={(v) => {
+                    setAnalyticsEndDate(v);
+                    setAnalyticsPreset("custom");
+                  }}
+                />
               </div>
               {loadingAnalytics ? (
                 <div className="flex justify-center py-12"><div className="w-8 h-8 border-4 border-[#2563EB] border-t-transparent rounded-full animate-spin" /></div>
@@ -1204,7 +1339,7 @@ export default function AdminPage() {
                     </ResponsiveContainer>
                   </div>
                   <div className="bg-white rounded-2xl p-6 shadow-sm border border-gray-200 mb-6">
-                    <h3 className="font-semibold text-gray-900 mb-4">페이지별 방문자 수 (최근 30일)</h3>
+                    <h3 className="font-semibold text-gray-900 mb-4">페이지별 방문자 수</h3>
                     <ResponsiveContainer width="100%" height={300}>
                       <BarChart data={pageVisitors.map((v) => ({ name: v.section_label, visits: v.count }))}>
                         <CartesianGrid strokeDasharray="3 3" stroke="#f0f0f0" />
@@ -1244,7 +1379,7 @@ export default function AdminPage() {
                       네트워크 게시글 · 학년×관심분야 조회
                     </h3>
                     <p className="text-sm text-gray-600 mb-6">
-                      조회 Top 10 · 글 제목 클릭 시 세그먼트 Top 3 · 최근 30일 · 로그인·학년·관심분야 있는 조회만
+                      조회 Top 10 · 글 제목 클릭 시 세그먼트 Top 3 · 로그인·학년·관심분야 있는 조회만
                     </p>
                     {postSegmentViews.length === 0 ? (
                       <p className="text-center text-gray-500 py-8">
@@ -1706,9 +1841,33 @@ export default function AdminPage() {
           {/* ── 검색 분석 ── */}
           {currentView === "searchAnalytics" && (
             <>
-              <div className="mb-8">
-                <h1 className="text-3xl font-bold text-gray-900 mb-2">검색 분석: 인기 키워드</h1>
-                <p className="text-gray-600">학생들이 가장 관심을 두는 키워드 분석</p>
+              <div className="mb-8 flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+                <div>
+                  <h1 className="text-3xl font-bold text-gray-900 mb-2">검색 분석: 인기 키워드</h1>
+                  <p className="text-gray-600">학생들이 가장 관심을 두는 키워드 분석</p>
+                  <p className="text-sm text-gray-500 mt-1">
+                    집계 기간: {searchStartDate} ~ {searchEndDate}
+                  </p>
+                </div>
+                <PeriodRangeControls
+                  preset={searchPreset}
+                  startDate={searchStartDate}
+                  endDate={searchEndDate}
+                  onPreset={(d) => {
+                    const range = dashboardPresetRange(d);
+                    setSearchPreset(d);
+                    setSearchStartDate(range.start);
+                    setSearchEndDate(range.end);
+                  }}
+                  onStartDateChange={(v) => {
+                    setSearchStartDate(v);
+                    setSearchPreset("custom");
+                  }}
+                  onEndDateChange={(v) => {
+                    setSearchEndDate(v);
+                    setSearchPreset("custom");
+                  }}
+                />
               </div>
               {loadingSearch ? (
                 <div className="flex justify-center py-12"><div className="w-8 h-8 border-4 border-[#2563EB] border-t-transparent rounded-full animate-spin" /></div>
@@ -1799,9 +1958,33 @@ export default function AdminPage() {
           {/* ── 세션 분석 ── */}
           {currentView === "sessions" && (
             <>
-              <div className="mb-8">
-                <h1 className="text-3xl font-bold text-gray-900 mb-2">세션 분석</h1>
-                <p className="text-gray-600">평균 세션·체류시간, 학년별 평균 세션 시간, 세션 시간 분포 (최근 30일)</p>
+              <div className="mb-8 flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+                <div>
+                  <h1 className="text-3xl font-bold text-gray-900 mb-2">세션 분석</h1>
+                  <p className="text-gray-600">평균 세션·체류시간, 학년별 평균 세션 시간, 세션 시간 분포</p>
+                  <p className="text-sm text-gray-500 mt-1">
+                    집계 기간: {sessionsStartDate} ~ {sessionsEndDate}
+                  </p>
+                </div>
+                <PeriodRangeControls
+                  preset={sessionsPreset}
+                  startDate={sessionsStartDate}
+                  endDate={sessionsEndDate}
+                  onPreset={(d) => {
+                    const range = dashboardPresetRange(d);
+                    setSessionsPreset(d);
+                    setSessionsStartDate(range.start);
+                    setSessionsEndDate(range.end);
+                  }}
+                  onStartDateChange={(v) => {
+                    setSessionsStartDate(v);
+                    setSessionsPreset("custom");
+                  }}
+                  onEndDateChange={(v) => {
+                    setSessionsEndDate(v);
+                    setSessionsPreset("custom");
+                  }}
+                />
               </div>
               {/* KPI 카드 */}
               {loadingSession ? (
@@ -1830,7 +2013,7 @@ export default function AdminPage() {
               )}
               <div className="bg-white rounded-2xl p-6 shadow-sm border border-gray-200 mb-8">
                 <h3 className="font-semibold text-gray-900 mb-2">섹션 전환 흐름 (Funnel)</h3>
-                <p className="text-sm text-gray-600 mb-6">세션 내 페이지뷰 순서 기준 상위 전환 (최근 30일)</p>
+                <p className="text-sm text-gray-600 mb-6">세션 내 페이지뷰 순서 기준 상위 전환</p>
                 {loadingSessionAnalytics ? (
                   <div className="flex justify-center py-8"><div className="w-8 h-8 border-4 border-[#2563EB] border-t-transparent rounded-full animate-spin" /></div>
                 ) : sessionTransitions.length === 0 ? (

--- a/frontend/src/shared/api/logs.ts
+++ b/frontend/src/shared/api/logs.ts
@@ -18,7 +18,13 @@ export function sendPageView(section: string, page?: string, sessionId?: string)
   });
 }
 
-// ─── 대시보드 KPI (기간별 집계, days=1|7|30) ───
+// ─── 대시보드 KPI (기간별 집계) ───
+export interface AnalyticsPeriodParams {
+  days?: number;
+  start_date?: string;
+  end_date?: string;
+}
+
 export interface DashboardKpi {
   today_logins: number;
   today_signups: number;
@@ -30,8 +36,10 @@ export interface DashboardKpi {
   engagement_rate: number;
   unique_visitors: number;
   days?: number;
+  start_date?: string;
+  end_date?: string;
 }
-export const getDashboardKpi = (params?: { days?: number }) =>
+export const getDashboardKpi = (params?: AnalyticsPeriodParams) =>
   api.get<DashboardKpi>("logs/analytics/dashboard-kpi/", { params });
 
 // ─── 운영 로그 (EventLog 목록) ───
@@ -65,8 +73,8 @@ export interface HeatmapRow {
   author_grade_label: string;
   cols: { viewer_grade: number | string; viewer_grade_label: string; score: number }[];
 }
-export const getHeatmap = () =>
-  api.get<{ rows: HeatmapRow[] }>("logs/analytics/heatmap/");
+export const getHeatmap = (params?: AnalyticsPeriodParams) =>
+  api.get<{ rows: HeatmapRow[] }>("logs/analytics/heatmap/", { params });
 
 // ─── 학년별 인기 글 ───
 export interface PopularByGradePost {
@@ -80,7 +88,7 @@ export interface PopularByGradeGroup {
   viewer_grade_label: string;
   posts: PopularByGradePost[];
 }
-export const getPopularByGrade = (params?: { top_n?: number }) =>
+export const getPopularByGrade = (params?: AnalyticsPeriodParams & { top_n?: number }) =>
   api.get<{ by_grade: PopularByGradeGroup[] }>(
     "logs/analytics/popular-by-grade/",
     { params }
@@ -97,10 +105,9 @@ export interface PopularByInterestGroup {
   interest_label: string;
   posts: PopularByInterestPost[];
 }
-export const getPopularByInterest = (params?: {
+export const getPopularByInterest = (params?: AnalyticsPeriodParams & {
   section?: string;
   top_n?: number;
-  days?: number;
 }) =>
   api.get<{ section: string; by_interest: PopularByInterestGroup[] }>(
     "logs/analytics/popular-by-interest/",
@@ -123,13 +130,18 @@ export interface PostSegmentViewPost {
   primary_segment: PostSegmentItem | null;
   top_segments: PostSegmentItem[];
 }
-export const getPostSegmentViews = (params?: {
+export const getPostSegmentViews = (params?: AnalyticsPeriodParams & {
   section?: string;
   top_posts?: number;
   top_segments?: number;
-  days?: number;
 }) =>
-  api.get<{ section: string; days: number; posts: PostSegmentViewPost[] }>(
+  api.get<{
+    section: string;
+    days?: number;
+    start_date?: string;
+    end_date?: string;
+    posts: PostSegmentViewPost[];
+  }>(
     "logs/analytics/post-segment-views/",
     { params }
   );
@@ -140,7 +152,7 @@ export interface PageVisitorItem {
   section_label: string;
   count: number;
 }
-export const getPageVisitors = (params?: { days?: number }) =>
+export const getPageVisitors = (params?: AnalyticsPeriodParams) =>
   api.get<{ by_section: PageVisitorItem[] }>("logs/analytics/page-visitors/", {
     params,
   });
@@ -157,7 +169,7 @@ export interface KnowledgeScoreItem {
   like_score: number;
   total_score: number;
 }
-export const getKnowledgeDeliveryScore = (params?: { days?: number }) =>
+export const getKnowledgeDeliveryScore = (params?: AnalyticsPeriodParams) =>
   api.get<{ by_grade: KnowledgeScoreItem[] }>(
     "logs/analytics/knowledge-delivery-score/",
     { params }
@@ -266,7 +278,7 @@ export interface SearchRankingItem {
   main_interest: string | null;
   main_interest_label: string;
 }
-export const getSearchRanking = (params?: {
+export const getSearchRanking = (params?: AnalyticsPeriodParams & {
   section?: string;
   top_n?: number;
   interest?: string;
@@ -282,7 +294,7 @@ export interface SessionStats {
   average_session_display: string;
   total_sessions: number;
 }
-export const getSessionStats = (params?: { days?: number }) =>
+export const getSessionStats = (params?: AnalyticsPeriodParams) =>
   api.get<SessionStats>("logs/analytics/session-stats/", { params });
 
 // ─── Session analytics (학년별 평균 세션 시간 + 세션 시간 분포) ───
@@ -296,7 +308,7 @@ export interface SessionDistributionBucket {
   bucket: string;
   count: number;
 }
-export const getSessionAnalytics = (params?: { days?: number }) =>
+export const getSessionAnalytics = (params?: AnalyticsPeriodParams) =>
   api.get<{
     by_grade: SessionByGrade[];
     distribution: SessionDistributionBucket[];
@@ -315,7 +327,7 @@ export interface SectionVisit {
   label: string;
   visits: number;
 }
-export const getSessionJourney = (params?: { top_n?: number }) =>
+export const getSessionJourney = (params?: AnalyticsPeriodParams & { top_n?: number }) =>
   api.get<{ transitions: SessionTransition[]; section_visits: SectionVisit[] }>(
     "logs/analytics/session-journey/",
     { params }


### PR DESCRIPTION
대시보드·행동분석·세션·검색 탭에 달력 기간 필터를 추가하고 관련 API에 start_date/end_date를 지원합니다.

## 🔗 관련 이슈
- close #

---

## 📌 작업 유형
- [ ] FE
- [ ] BE

---

## ✨ 작업 내용
### FE
- (프론트 작업 내용)

### BE
- (백엔드 작업 내용)

---

## ✅ 체크리스트
- [ ] 로컬에서 정상 동작 확인
- [ ] 불필요한 코드 제거
- [ ] 컨벤션 준수
- [ ] 리뷰 요청 완료

---

## 📎 추가 자료 
- 새로 다운받은 것이 있다면 꼭 작성하고, 말해주세요 