### PR TITLE
fix: 활동점수  및 Admin 인기 글 점수 UI 제거

### DIFF
--- a/backend/apps/users/management/commands/reset_monthly_scores.py
+++ b/backend/apps/users/management/commands/reset_monthly_scores.py
@@ -16,7 +16,7 @@ from django.db.models import Q
 from apps.users.models import User, ScoreHistory, MonthlyWinner
 
 
-EXCLUDED_NICKNAMES = {"wldud", "김만덕", "김승혁", "도도도", "leewise", "농진", "23", "몽당연필", "에사비"}
+EXCLUDED_NICKNAMES = {"wldud", "김만덕", "김승혁", "도도도", "leewise", "농진", "23", "몽당연필", "에사비", "애사비"}
 
 
 class Command(BaseCommand):

--- a/backend/apps/users/views.py
+++ b/backend/apps/users/views.py
@@ -693,7 +693,7 @@ class CompleteProfileView(generics.GenericAPIView):
     
 
 # 제외할 닉네임 목록
-EXCLUDED_NICKNAMES = {"wldud", "김만덕", "김승혁", "도도도", "leewise", "농진", "23", "몽당연필", "에사비"}
+EXCLUDED_NICKNAMES = {"wldud", "김만덕", "김승혁", "도도도", "leewise", "농진", "23", "몽당연필", "에사비", "애사비"}
 
 
 # 순위 불러 오기 (과거 수상자 제외)

--- a/frontend/src/app/admin/page.tsx
+++ b/frontend/src/app/admin/page.tsx
@@ -1365,7 +1365,6 @@ export default function AdminPage() {
                                 <li key={`${post.section}-${post.post_id}`} className="text-sm">
                                   <span className="text-gray-400 mr-2">{idx + 1}.</span>
                                   <span className="text-gray-800">{post.title || `글 #${post.post_id}`}</span>
-                                  <span className="text-xs text-gray-500 ml-1">({post.score}점)</span>
                                 </li>
                               ))}
                             </ol>


### PR DESCRIPTION
활동 우수자·월간 점수 집계에서 애사비 닉네임을 제외하고, 학년별 인기 글 목록에서 점수 표시를 숨깁니다.

## 🔗 관련 이슈
- close #

---

## 📌 작업 유형
- [ ] FE
- [ ] BE

---

## ✨ 작업 내용
### FE
- (프론트 작업 내용)

### BE
- (백엔드 작업 내용)

---

## ✅ 체크리스트
- [ ] 로컬에서 정상 동작 확인
- [ ] 불필요한 코드 제거
- [ ] 컨벤션 준수
- [ ] 리뷰 요청 완료

---

## 📎 추가 자료 
- 새로 다운받은 것이 있다면 꼭 작성하고, 말해주세요 